### PR TITLE
feat: add shebang for unix-like execution

### DIFF
--- a/python_version.py
+++ b/python_version.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Python Version Manager - CLI Tool
 Checks and installs Python to the latest version across Windows, Linux, and macOS


### PR DESCRIPTION
### Description
This PR adds the standard Python shebang `#!/usr/bin/env python3` to the top of `python_version.py`.

### Changes
- Added `#!/usr/bin/env python3` as the very first line of `python_version.py`.

### Tests 
Following the project's contribution guidelines:
1. Checked syntax: `python -m py_compile python_version.py` (Passed with no errors).
2. Verified local execution: Ran `python python_version.py check` and `python python_version.py info` on Windows 
3. Confirmed the shebang is the first line, before any docstrings or imports.

### Related Issue
Issue #3