### PR TITLE
feat: add Python 3.13 and 3.14 classifiers in setup.py (#2)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.7",


### PR DESCRIPTION
Added Python 3.13 and 3.14 classifiers in setup.py.

Versions are now available.