### PR TITLE
fixes_#1: add short -v flag for version command

### DIFF
--- a/python_version.py
+++ b/python_version.py
@@ -511,7 +511,7 @@ def show_python_usage_instructions(version_str: str, os_name: str):
 
 @click.group(invoke_without_command=True)
 @click.pass_context
-@click.option('--version', is_flag=True, help='Show tool version')
+@click.option('--version', '-v', is_flag=True, help='Show tool version')
 def cli(ctx, version):
     """Python Version Manager - Check and install Python (does NOT modify system defaults)"""
     if version:


### PR DESCRIPTION
- Description
I have added the short flag `-v` to the existing `--version` option to improve usability. This change was implemented by updating the `@click.option` decorator in `python_version.py` (line 514).

- Related Issue
Closes #1

- Verification
I have verified that the command works as expected locally.
Attached are screenshots showing:
1. The updated output of `pyvm --help` displaying both flags.
2. The successful execution of both `pyvm -v` and `pyvm --version`.

- Screenshots:
<img width="1920" height="1080" alt="add_-v_flag_issue_1" src="https://github.com/user-attachments/assets/6ee62ebb-019a-4201-803a-cdd7e1a1eadc" />
<img width="1920" height="1080" alt="show_-v_flag_on_--help" src="https://github.com/user-attachments/assets/6692e775-339f-4642-80db-0f40f5663104" />
