### PR TITLE
feat: update python_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "Programming Language :: Python :: 3.14",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     install_requires=[
         "requests>=2.25.0",
         "beautifulsoup4>=4.9.0",


### PR DESCRIPTION
change "python_requires= "from ">=3.7" to ">=3.9" cause 3.7 and 3.8 python versions reached ELO

also tests passed on 3.13 and 3.14 versions