### PR TITLE
#7 Add SHA256 checksum verification for Python downloads

### DIFF
--- a/python_version.py
+++ b/python_version.py
@@ -23,7 +23,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 try:
     import click
@@ -101,7 +101,7 @@ def calculate_sha256(file_path: str) -> str:
     return sha256.hexdigest()
 
 
-def fetch_remote_sha256(checksum_url: str) -> Optional[str]:
+def fetch_remote_sha256(checksum_url: str) -> str | None:
     """Fetch SHA256 checksum from python.org"""
     try:
         response = requests.get(checksum_url, timeout=REQUEST_TIMEOUT)


### PR DESCRIPTION
Downloaded Python installers are now verified against official python.org SHA256 checksums before execution.
Installation aborts safely on checksum mismatch or fetch failure.
<img width="1082" height="249" alt="Screenshot 2026-01-14 105210" src="https://github.com/user-attachments/assets/758d73d7-64ed-4089-b432-33d20e3b6c63" />
