### PR TITLE
fix: consolidate data file locations to follow XDG Base Directory Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ pyvm config --path    # Show config file location
 - **Config / Data / Cache:** `%LOCALAPPDATA%\pyvm\`
 
 ### Automatic Migration for Existing Users
-If you are upgrading from an older version of `pyvm` that used legacy paths (e.g., `~/.pyvm`, `~/.pyvm_history.json`), the tool will **automatically migrate** your files and virtual environments to the new locations the next time you run any `pyvm` command. 
+If you are upgrading from an older version of `pyvm` that used legacy paths (e.g., `~/.pyvm`, `~/.pyvm_history.json`), the tool will **automatically migrate** your files and virtual environments to the new locations the next time you run any `pyvm` command.
 
 * **Logs:** If you run into issues, check your terminal output. Failed partial migrations will be retried automatically on subsequent runs until successful.
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,23 @@ pyvm config --init    # Create default config
 pyvm config --path    # Show config file location
 ```
 
+## Data Locations (XDG Compliance)
+
+`pyvm` stores configuration, data, and cache files following the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) on Linux/macOS, and standard `LocalAppData` locations on Windows.
+
+**Linux / macOS:**
+- **Config:** `~/.config/pyvm/` (`$XDG_CONFIG_HOME`)
+- **Data (Venvs/History):** `~/.local/share/pyvm/` (`$XDG_DATA_HOME`)
+- **Cache (Metadata):** `~/.cache/pyvm/` (`$XDG_CACHE_HOME`)
+
+**Windows:**
+- **Config / Data / Cache:** `%LOCALAPPDATA%\pyvm\`
+
+### Automatic Migration for Existing Users
+If you are upgrading from an older version of `pyvm` that used legacy paths (e.g., `~/.pyvm`, `~/.pyvm_history.json`), the tool will **automatically migrate** your files and virtual environments to the new locations the next time you run any `pyvm` command. 
+
+* **Logs:** If you run into issues, check your terminal output. Failed partial migrations will be retried automatically on subsequent runs until successful.
+
 ## Requirements
 
 - Python 3.9 or higher

--- a/src/pyvm_updater/cli.py
+++ b/src/pyvm_updater/cli.py
@@ -27,6 +27,7 @@ from .installers import (
     update_python_windows,
 )
 from .logging_config import get_logger, setup_logging
+from .paths import ensure_directories, migrate_legacy_paths
 from .utils import get_os_info, is_admin, validate_version_string
 from .version import (
     check_python_version,
@@ -48,6 +49,10 @@ def cli(ctx: click.Context, version: bool, verbose: bool, quiet: bool) -> None:
     """Python Version Manager - Check and install Python (does NOT modify system defaults)"""
     # Initialize logging
     setup_logging(verbose=verbose, quiet=quiet)
+
+    # Ensure XDG directories exist and migrate legacy paths on first run
+    ensure_directories()
+    migrate_legacy_paths()
 
     # Store config in context for subcommands
     ctx.ensure_object(dict)

--- a/src/pyvm_updater/config.py
+++ b/src/pyvm_updater/config.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from .paths import get_config_dir, get_config_file as _get_config_file
+
 # Try to import tomllib (Python 3.11+) or fallback to tomli
 try:
     import tomllib
@@ -14,9 +16,9 @@ except ImportError:
     except ImportError:
         tomllib = None  # type: ignore
 
-# Config file location
-CONFIG_DIR = Path.home() / ".config" / "pyvm"
-CONFIG_FILE = CONFIG_DIR / "config.toml"
+# Config file location (XDG-compliant)
+CONFIG_DIR = get_config_dir()
+CONFIG_FILE = _get_config_file()
 
 # Default configuration
 DEFAULT_CONFIG: dict[str, Any] = {

--- a/src/pyvm_updater/config.py
+++ b/src/pyvm_updater/config.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
-from .paths import get_config_dir, get_config_file as _get_config_file
+from .paths import get_config_dir
+from .paths import get_config_file as _get_config_file
 
 # Try to import tomllib (Python 3.11+) or fallback to tomli
 try:

--- a/src/pyvm_updater/constants.py
+++ b/src/pyvm_updater/constants.py
@@ -1,7 +1,7 @@
 # Configuration and constants for pyvm_updater
 """Constants and configuration for pyvm_updater."""
 
-from pathlib import Path
+from .paths import get_cache_dir, get_data_dir
 
 # Network configuration
 MAX_RETRIES = 3
@@ -9,9 +9,9 @@ RETRY_DELAY = 2  # seconds
 DOWNLOAD_TIMEOUT = 120  # seconds
 REQUEST_TIMEOUT = 15  # seconds
 
-# History file location
-HISTORY_FILE = Path.home() / ".pyvm_history.json"
+# History file location (XDG_DATA_HOME/pyvm/history.json)
+HISTORY_FILE = get_data_dir() / "history.json"
 
-# Local metadata cache (versions, security, EOL)
-METADATA_DB = Path.home() / ".pyvm_metadata.sqlite"
+# Local metadata cache (XDG_CACHE_HOME/pyvm/metadata.sqlite)
+METADATA_DB = get_cache_dir() / "metadata.sqlite"
 METADATA_TTL_SECONDS = 24 * 60 * 60  # 24h TTL for cached metadata

--- a/src/pyvm_updater/paths.py
+++ b/src/pyvm_updater/paths.py
@@ -127,9 +127,7 @@ def _move_file(src: Path, dst: Path) -> bool:
             shutil.move(str(src), str(dst))
             log.info(f"Migrated {src} -> {dst}")
         else:
-            log.warning(
-                f"Destination {dst} already exists; keeping legacy {src} to avoid data loss."
-            )
+            log.warning(f"Destination {dst} already exists; keeping legacy {src} to avoid data loss.")
             return False
         return not src.exists()
     except (OSError, shutil.Error) as e:
@@ -151,10 +149,7 @@ def _move_directory(src: Path, dst: Path) -> bool:
                 if not target.exists():
                     shutil.move(str(item), str(target))
                 else:
-                    log.warning(
-                        f"Conflict: {target} already exists; "
-                        f"keeping legacy {item} in place."
-                    )
+                    log.warning(f"Conflict: {target} already exists; keeping legacy {item} in place.")
                     has_conflicts = True
             # Only remove source dir if it's now empty
             if not any(src.iterdir()):

--- a/src/pyvm_updater/paths.py
+++ b/src/pyvm_updater/paths.py
@@ -206,17 +206,18 @@ def migrate_legacy_paths() -> None:
             # Rewrite any legacy venv paths in the registry
             try:
                 import json
+
                 legacy_venv_dir = str(_LEGACY_PATHS["venv_dir"])
                 new_venv_dir = str(get_venv_dir())
-                with open(new_registry, "r", encoding="utf-8") as f:
+                with open(new_registry, encoding="utf-8") as f:
                     registry = json.load(f)
                 changed = False
-                for venv, meta in registry.items():
+                for _venv, meta in registry.items():
                     # If the registry entry has a path under the legacy root, rewrite it
                     if isinstance(meta, dict) and "path" in meta:
                         path_val = meta["path"]
                         if isinstance(path_val, str) and path_val.startswith(legacy_venv_dir):
-                            meta["path"] = new_venv_dir + path_val[len(legacy_venv_dir):]
+                            meta["path"] = new_venv_dir + path_val[len(legacy_venv_dir) :]
                             changed = True
                 if changed:
                     with open(new_registry, "w", encoding="utf-8") as f:

--- a/src/pyvm_updater/paths.py
+++ b/src/pyvm_updater/paths.py
@@ -118,23 +118,29 @@ def _mark_migration_done() -> None:
 
 
 def _move_file(src: Path, dst: Path) -> bool:
-    """Move a single file from src to dst. Returns True on success."""
+    """Move a single file from src to dst. Returns True if src is successfully moved and no longer exists."""
     if not src.exists():
-        return False
+        return True
     try:
         dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(src), str(dst))
-        log.info(f"Migrated {src} -> {dst}")
-        return True
+        if not dst.exists():
+            shutil.move(str(src), str(dst))
+            log.info(f"Migrated {src} -> {dst}")
+        else:
+            # If destination already exists, we prefer it but we must remove the legacy source
+            # to prevent partial migration state. We log that we skipped overwriting.
+            log.info(f"Destination {dst} already exists, skipping move. Removing legacy {src}.")
+            src.unlink()
+        return not src.exists()
     except (OSError, shutil.Error) as e:
         log.warning(f"Failed to migrate {src} -> {dst}: {e}")
         return False
 
 
 def _move_directory(src: Path, dst: Path) -> bool:
-    """Move a directory tree from src to dst. Returns True on success."""
+    """Move a directory tree from src to dst. Returns True if src is successfully moved and no longer exists."""
     if not src.exists() or not src.is_dir():
-        return False
+        return True
     try:
         dst.parent.mkdir(parents=True, exist_ok=True)
         if dst.exists():
@@ -147,7 +153,7 @@ def _move_directory(src: Path, dst: Path) -> bool:
         else:
             shutil.move(str(src), str(dst))
         log.info(f"Migrated {src} -> {dst}")
-        return True
+        return not src.exists()
     except (OSError, shutil.Error) as e:
         log.warning(f"Failed to migrate {src} -> {dst}: {e}")
         return False
@@ -163,30 +169,39 @@ def migrate_legacy_paths() -> None:
     if _migration_done():
         return
 
+    success = True
     migrated_any = False
 
     # History file
     old_history = _LEGACY_PATHS["history"]
     if old_history.exists():
-        if _move_file(old_history, get_history_file()):
+        if not _move_file(old_history, get_history_file()):
+            success = False
+        else:
             migrated_any = True
 
     # Metadata cache
     old_metadata = _LEGACY_PATHS["metadata"]
     if old_metadata.exists():
-        if _move_file(old_metadata, get_metadata_db()):
+        if not _move_file(old_metadata, get_metadata_db()):
+            success = False
+        else:
             migrated_any = True
 
     # Venv registry
     old_registry = _LEGACY_PATHS["venv_registry"]
     if old_registry.exists():
-        if _move_file(old_registry, get_venv_registry_file()):
+        if not _move_file(old_registry, get_venv_registry_file()):
+            success = False
+        else:
             migrated_any = True
 
     # Venv directory
     old_venv_dir = _LEGACY_PATHS["venv_dir"]
     if old_venv_dir.exists() and old_venv_dir.is_dir():
-        if _move_directory(old_venv_dir, get_venv_dir()):
+        if not _move_directory(old_venv_dir, get_venv_dir()):
+            success = False
+        else:
             migrated_any = True
 
     # Clean up empty ~/.pyvm directory if it's now empty
@@ -201,7 +216,8 @@ def migrate_legacy_paths() -> None:
     if migrated_any:
         log.info("Legacy file migration complete.")
 
-    _mark_migration_done()
+    if success:
+        _mark_migration_done()
 
 
 def ensure_directories() -> None:

--- a/src/pyvm_updater/paths.py
+++ b/src/pyvm_updater/paths.py
@@ -1,0 +1,211 @@
+"""Centralized path resolution following XDG Base Directory Specification.
+
+On Linux/macOS:
+    Config  -> $XDG_CONFIG_HOME/pyvm  (default: ~/.config/pyvm)
+    Data    -> $XDG_DATA_HOME/pyvm    (default: ~/.local/share/pyvm)
+    Cache   -> $XDG_CACHE_HOME/pyvm   (default: ~/.cache/pyvm)
+
+On Windows:
+    All     -> %LOCALAPPDATA%/pyvm
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import shutil
+from pathlib import Path
+
+log = logging.getLogger("pyvm.paths")
+
+_APP_NAME = "pyvm"
+
+
+def _is_windows() -> bool:
+    return platform.system() == "Windows"
+
+
+# --- XDG directory resolution ---
+
+
+def get_config_dir() -> Path:
+    """Return the configuration directory for pyvm."""
+    if _is_windows():
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+        return base / _APP_NAME / "config"
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg) / _APP_NAME
+    return Path.home() / ".config" / _APP_NAME
+
+
+def get_data_dir() -> Path:
+    """Return the data directory for pyvm (history, venvs, registry)."""
+    if _is_windows():
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+        return base / _APP_NAME / "data"
+    xdg = os.environ.get("XDG_DATA_HOME")
+    if xdg:
+        return Path(xdg) / _APP_NAME
+    return Path.home() / ".local" / "share" / _APP_NAME
+
+
+def get_cache_dir() -> Path:
+    """Return the cache directory for pyvm (metadata sqlite)."""
+    if _is_windows():
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+        return base / _APP_NAME / "cache"
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg:
+        return Path(xdg) / _APP_NAME
+    return Path.home() / ".cache" / _APP_NAME
+
+
+# --- Concrete file paths ---
+
+
+def get_config_file() -> Path:
+    return get_config_dir() / "config.toml"
+
+
+def get_history_file() -> Path:
+    return get_data_dir() / "history.json"
+
+
+def get_metadata_db() -> Path:
+    return get_cache_dir() / "metadata.sqlite"
+
+
+def get_venv_dir() -> Path:
+    return get_data_dir() / "venvs"
+
+
+def get_venv_registry_file() -> Path:
+    return get_data_dir() / "venvs.json"
+
+
+def get_plugins_dir() -> Path:
+    return get_config_dir() / "plugins"
+
+
+# --- Legacy paths (pre-XDG) ---
+
+_LEGACY_PATHS = {
+    "history": Path.home() / ".pyvm_history.json",
+    "metadata": Path.home() / ".pyvm_metadata.sqlite",
+    "venv_dir": Path.home() / ".pyvm" / "venvs",
+    "venv_registry": Path.home() / ".pyvm" / "venvs.json",
+    "config_dir": Path.home() / ".config" / "pyvm",
+    "config_file": Path.home() / ".config" / "pyvm" / "config.toml",
+}
+
+
+# --- Migration ---
+
+_MIGRATED_FLAG = ".migrated_xdg"
+
+
+def _migration_done() -> bool:
+    """Check if migration has already been performed."""
+    return (get_data_dir() / _MIGRATED_FLAG).exists()
+
+
+def _mark_migration_done() -> None:
+    """Write a flag file so migration only runs once."""
+    get_data_dir().mkdir(parents=True, exist_ok=True)
+    (get_data_dir() / _MIGRATED_FLAG).touch()
+
+
+def _move_file(src: Path, dst: Path) -> bool:
+    """Move a single file from src to dst. Returns True on success."""
+    if not src.exists():
+        return False
+    try:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(dst))
+        log.info(f"Migrated {src} -> {dst}")
+        return True
+    except (OSError, shutil.Error) as e:
+        log.warning(f"Failed to migrate {src} -> {dst}: {e}")
+        return False
+
+
+def _move_directory(src: Path, dst: Path) -> bool:
+    """Move a directory tree from src to dst. Returns True on success."""
+    if not src.exists() or not src.is_dir():
+        return False
+    try:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if dst.exists():
+            # Merge contents if destination already exists
+            for item in src.iterdir():
+                target = dst / item.name
+                if not target.exists():
+                    shutil.move(str(item), str(target))
+            shutil.rmtree(str(src), ignore_errors=True)
+        else:
+            shutil.move(str(src), str(dst))
+        log.info(f"Migrated {src} -> {dst}")
+        return True
+    except (OSError, shutil.Error) as e:
+        log.warning(f"Failed to migrate {src} -> {dst}: {e}")
+        return False
+
+
+def migrate_legacy_paths() -> None:
+    """Migrate data from old locations to XDG-compliant paths.
+
+    This runs once on first launch after the update. It moves files
+    from the legacy locations to the new XDG directories and writes
+    a flag file to prevent running again.
+    """
+    if _migration_done():
+        return
+
+    migrated_any = False
+
+    # History file
+    old_history = _LEGACY_PATHS["history"]
+    if old_history.exists():
+        if _move_file(old_history, get_history_file()):
+            migrated_any = True
+
+    # Metadata cache
+    old_metadata = _LEGACY_PATHS["metadata"]
+    if old_metadata.exists():
+        if _move_file(old_metadata, get_metadata_db()):
+            migrated_any = True
+
+    # Venv registry
+    old_registry = _LEGACY_PATHS["venv_registry"]
+    if old_registry.exists():
+        if _move_file(old_registry, get_venv_registry_file()):
+            migrated_any = True
+
+    # Venv directory
+    old_venv_dir = _LEGACY_PATHS["venv_dir"]
+    if old_venv_dir.exists() and old_venv_dir.is_dir():
+        if _move_directory(old_venv_dir, get_venv_dir()):
+            migrated_any = True
+
+    # Clean up empty ~/.pyvm directory if it's now empty
+    old_pyvm_dir = Path.home() / ".pyvm"
+    if old_pyvm_dir.exists() and old_pyvm_dir.is_dir():
+        try:
+            if not any(old_pyvm_dir.iterdir()):
+                old_pyvm_dir.rmdir()
+        except OSError:
+            pass
+
+    if migrated_any:
+        log.info("Legacy file migration complete.")
+
+    _mark_migration_done()
+
+
+def ensure_directories() -> None:
+    """Create all XDG directories if they don't exist."""
+    get_config_dir().mkdir(parents=True, exist_ok=True)
+    get_data_dir().mkdir(parents=True, exist_ok=True)
+    get_cache_dir().mkdir(parents=True, exist_ok=True)

--- a/src/pyvm_updater/paths.py
+++ b/src/pyvm_updater/paths.py
@@ -196,11 +196,33 @@ def migrate_legacy_paths() -> None:
 
     # Venv registry
     old_registry = _LEGACY_PATHS["venv_registry"]
+    new_registry = get_venv_registry_file()
     if old_registry.exists():
-        if not _move_file(old_registry, get_venv_registry_file()):
+        # Move the registry file first
+        if not _move_file(old_registry, new_registry):
             success = False
         else:
             migrated_any = True
+            # Rewrite any legacy venv paths in the registry
+            try:
+                import json
+                legacy_venv_dir = str(_LEGACY_PATHS["venv_dir"])
+                new_venv_dir = str(get_venv_dir())
+                with open(new_registry, "r", encoding="utf-8") as f:
+                    registry = json.load(f)
+                changed = False
+                for venv, meta in registry.items():
+                    # If the registry entry has a path under the legacy root, rewrite it
+                    if isinstance(meta, dict) and "path" in meta:
+                        path_val = meta["path"]
+                        if isinstance(path_val, str) and path_val.startswith(legacy_venv_dir):
+                            meta["path"] = new_venv_dir + path_val[len(legacy_venv_dir):]
+                            changed = True
+                if changed:
+                    with open(new_registry, "w", encoding="utf-8") as f:
+                        json.dump(registry, f, indent=2)
+            except Exception as e:
+                log.warning(f"Failed to rewrite legacy venv paths in registry: {e}")
 
     # Venv directory
     old_venv_dir = _LEGACY_PATHS["venv_dir"]

--- a/src/pyvm_updater/paths.py
+++ b/src/pyvm_updater/paths.py
@@ -127,10 +127,10 @@ def _move_file(src: Path, dst: Path) -> bool:
             shutil.move(str(src), str(dst))
             log.info(f"Migrated {src} -> {dst}")
         else:
-            # If destination already exists, we prefer it but we must remove the legacy source
-            # to prevent partial migration state. We log that we skipped overwriting.
-            log.info(f"Destination {dst} already exists, skipping move. Removing legacy {src}.")
-            src.unlink()
+            log.warning(
+                f"Destination {dst} already exists; keeping legacy {src} to avoid data loss."
+            )
+            return False
         return not src.exists()
     except (OSError, shutil.Error) as e:
         log.warning(f"Failed to migrate {src} -> {dst}: {e}")
@@ -144,12 +144,23 @@ def _move_directory(src: Path, dst: Path) -> bool:
     try:
         dst.parent.mkdir(parents=True, exist_ok=True)
         if dst.exists():
-            # Merge contents if destination already exists
+            # Merge non-conflicting contents; leave conflicts in source
+            has_conflicts = False
             for item in src.iterdir():
                 target = dst / item.name
                 if not target.exists():
                     shutil.move(str(item), str(target))
-            shutil.rmtree(str(src), ignore_errors=True)
+                else:
+                    log.warning(
+                        f"Conflict: {target} already exists; "
+                        f"keeping legacy {item} in place."
+                    )
+                    has_conflicts = True
+            # Only remove source dir if it's now empty
+            if not any(src.iterdir()):
+                src.rmdir()
+            if has_conflicts:
+                return False
         else:
             shutil.move(str(src), str(dst))
         log.info(f"Migrated {src} -> {dst}")

--- a/src/pyvm_updater/venv.py
+++ b/src/pyvm_updater/venv.py
@@ -11,14 +11,15 @@ from pathlib import Path
 from typing import Any
 
 from .logging_config import get_logger
+from .paths import get_venv_dir as _get_venv_dir, get_venv_registry_file
 from .utils import get_os_info
 from .version import get_installed_python_versions
 
 log = get_logger("venv")
 
-# Default venv directory
-DEFAULT_VENV_DIR = Path.home() / ".pyvm" / "venvs"
-VENV_REGISTRY = Path.home() / ".pyvm" / "venvs.json"
+# Default venv directory (XDG_DATA_HOME/pyvm/venvs)
+DEFAULT_VENV_DIR = _get_venv_dir()
+VENV_REGISTRY = get_venv_registry_file()
 
 
 def get_venv_dir() -> Path:

--- a/src/pyvm_updater/venv.py
+++ b/src/pyvm_updater/venv.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from typing import Any
 
 from .logging_config import get_logger
-from .paths import get_venv_dir as _get_venv_dir, get_venv_registry_file
+from .paths import get_venv_dir as _get_venv_dir
+from .paths import get_venv_registry_file
 from .utils import get_os_info
 from .version import get_installed_python_versions
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,13 @@
 import pytest
 from click.testing import CliRunner
+
 from pyvm_updater.cli import cli
+
 
 @pytest.fixture
 def runner():
     return CliRunner()
+
 
 def test_install_dry_run(runner):
     """Verify that the install dry-run flag prints the correct message and exits 0."""
@@ -12,6 +15,7 @@ def test_install_dry_run(runner):
     assert result.exit_code == 0
     assert "[DRY-RUN]" in result.output
     assert "Would download and install Python 3.12.1" in result.output
+
 
 def test_remove_dry_run(runner):
     """Verify that the remove dry-run flag prints the correct message and exits 0."""

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -115,41 +115,43 @@ class TestConcreteFilePaths:
 
 
 class TestMigration:
+    """Tests for legacy path migration."""
 
     def test_registry_path_rewrite_on_migration(self, migration_env):
         """Test that legacy venv paths in venvs.json are rewritten to new root."""
         import json
+
         env = migration_env
 
         # Write a legacy registry with an absolute path under the old venv root
         legacy_venv_dir = env["legacy_pyvm"] / "venvs"
         legacy_registry = env["legacy_pyvm"] / "venvs.json"
         legacy_path = str(legacy_venv_dir / "myenv")
-        registry_data = {
-            "myenv": {
-                "path": legacy_path,
-                "python": "3.12.1"
-            }
-        }
+        registry_data = {"myenv": {"path": legacy_path, "python": "3.12.1"}}
         legacy_registry.write_text(json.dumps(registry_data))
 
-        with patch("pyvm_updater.paths.get_data_dir", return_value=env["data_dir"]):
-            with patch("pyvm_updater.paths.get_cache_dir", return_value=env["cache_dir"]):
-                with patch("pyvm_updater.paths.get_history_file", return_value=env["data_dir"] / "history.json"):
-                    with patch("pyvm_updater.paths.get_metadata_db", return_value=env["cache_dir"] / "metadata.sqlite"):
-                        with patch("pyvm_updater.paths.get_venv_registry_file", return_value=env["data_dir"] / "venvs.json"):
-                            with patch("pyvm_updater.paths.get_venv_dir", return_value=env["data_dir"] / "venvs"):
-                                with patch("pyvm_updater.paths._LEGACY_PATHS", {
-                                    "history": env["legacy_history"],
-                                    "metadata": env["legacy_metadata"],
-                                    "venv_dir": legacy_venv_dir,
-                                    "venv_registry": legacy_registry,
-                                    "config_dir": env["home"] / ".config" / "pyvm",
-                                    "config_file": env["home"] / ".config" / "pyvm" / "config.toml",
-                                }):
-                                    with patch("pyvm_updater.paths._migration_done", return_value=False):
-                                        with patch("pyvm_updater.paths._mark_migration_done"):
-                                            migrate_legacy_paths()
+        with (
+            patch("pyvm_updater.paths.get_data_dir", return_value=env["data_dir"]),
+            patch("pyvm_updater.paths.get_cache_dir", return_value=env["cache_dir"]),
+            patch("pyvm_updater.paths.get_history_file", return_value=env["data_dir"] / "history.json"),
+            patch("pyvm_updater.paths.get_metadata_db", return_value=env["cache_dir"] / "metadata.sqlite"),
+            patch("pyvm_updater.paths.get_venv_registry_file", return_value=env["data_dir"] / "venvs.json"),
+            patch("pyvm_updater.paths.get_venv_dir", return_value=env["data_dir"] / "venvs"),
+            patch(
+                "pyvm_updater.paths._LEGACY_PATHS",
+                {
+                    "history": env["legacy_history"],
+                    "metadata": env["legacy_metadata"],
+                    "venv_dir": legacy_venv_dir,
+                    "venv_registry": legacy_registry,
+                    "config_dir": env["home"] / ".config" / "pyvm",
+                    "config_file": env["home"] / ".config" / "pyvm" / "config.toml",
+                },
+            ),
+            patch("pyvm_updater.paths._migration_done", return_value=False),
+            patch("pyvm_updater.paths._mark_migration_done"),
+        ):
+            migrate_legacy_paths()
 
         # The migrated registry should have the path rewritten to the new venv dir
         migrated_registry_path = env["data_dir"] / "venvs.json"
@@ -159,6 +161,7 @@ class TestMigration:
         new_venv_dir = str(env["data_dir"] / "venvs")
         assert "myenv" in migrated
         assert migrated["myenv"]["path"].startswith(new_venv_dir)
+
     """Tests for legacy path migration."""
 
     @pytest.fixture

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -115,6 +115,50 @@ class TestConcreteFilePaths:
 
 
 class TestMigration:
+
+    def test_registry_path_rewrite_on_migration(self, migration_env):
+        """Test that legacy venv paths in venvs.json are rewritten to new root."""
+        import json
+        env = migration_env
+
+        # Write a legacy registry with an absolute path under the old venv root
+        legacy_venv_dir = env["legacy_pyvm"] / "venvs"
+        legacy_registry = env["legacy_pyvm"] / "venvs.json"
+        legacy_path = str(legacy_venv_dir / "myenv")
+        registry_data = {
+            "myenv": {
+                "path": legacy_path,
+                "python": "3.12.1"
+            }
+        }
+        legacy_registry.write_text(json.dumps(registry_data))
+
+        with patch("pyvm_updater.paths.get_data_dir", return_value=env["data_dir"]):
+            with patch("pyvm_updater.paths.get_cache_dir", return_value=env["cache_dir"]):
+                with patch("pyvm_updater.paths.get_history_file", return_value=env["data_dir"] / "history.json"):
+                    with patch("pyvm_updater.paths.get_metadata_db", return_value=env["cache_dir"] / "metadata.sqlite"):
+                        with patch("pyvm_updater.paths.get_venv_registry_file", return_value=env["data_dir"] / "venvs.json"):
+                            with patch("pyvm_updater.paths.get_venv_dir", return_value=env["data_dir"] / "venvs"):
+                                with patch("pyvm_updater.paths._LEGACY_PATHS", {
+                                    "history": env["legacy_history"],
+                                    "metadata": env["legacy_metadata"],
+                                    "venv_dir": legacy_venv_dir,
+                                    "venv_registry": legacy_registry,
+                                    "config_dir": env["home"] / ".config" / "pyvm",
+                                    "config_file": env["home"] / ".config" / "pyvm" / "config.toml",
+                                }):
+                                    with patch("pyvm_updater.paths._migration_done", return_value=False):
+                                        with patch("pyvm_updater.paths._mark_migration_done"):
+                                            migrate_legacy_paths()
+
+        # The migrated registry should have the path rewritten to the new venv dir
+        migrated_registry_path = env["data_dir"] / "venvs.json"
+        assert migrated_registry_path.exists()
+        with open(migrated_registry_path, encoding="utf-8") as f:
+            migrated = json.load(f)
+        new_venv_dir = str(env["data_dir"] / "venvs")
+        assert "myenv" in migrated
+        assert migrated["myenv"]["path"].startswith(new_venv_dir)
     """Tests for legacy path migration."""
 
     @pytest.fixture

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 import pytest
 
 from pyvm_updater.paths import (
+    _move_directory,
+    _move_file,
     get_cache_dir,
     get_config_dir,
     get_data_dir,
@@ -196,6 +198,139 @@ class TestMigration:
         # Legacy files should still exist (not moved)
         assert env["legacy_history"].exists()
         assert env["legacy_metadata"].exists()
+
+    def test_move_file_preserves_source_on_conflict(self, tmp_path):
+        """_move_file must NOT delete source when destination already exists."""
+        src = tmp_path / "legacy.json"
+        dst = tmp_path / "xdg" / "data.json"
+        src.write_text('{"legacy": true}')
+        dst.parent.mkdir(parents=True)
+        dst.write_text('{"xdg": true}')
+
+        result = _move_file(src, dst)
+
+        assert result is False
+        # Both files must still exist with original content
+        assert src.exists()
+        assert src.read_text() == '{"legacy": true}'
+        assert dst.read_text() == '{"xdg": true}'
+
+    def test_move_directory_partial_overlap_preserves_conflicts(self, tmp_path):
+        """Non-conflicting items are moved; conflicting items stay in source."""
+        src = tmp_path / "src_dir"
+        dst = tmp_path / "dst_dir"
+        src.mkdir()
+        dst.mkdir()
+
+        # Conflicting item (exists in both)
+        (src / "conflict.txt").write_text("src-version")
+        (dst / "conflict.txt").write_text("dst-version")
+
+        # Non-conflicting item (only in source)
+        (src / "unique.txt").write_text("only-in-src")
+
+        result = _move_directory(src, dst)
+
+        assert result is False
+        # Conflicting file preserved in source
+        assert (src / "conflict.txt").exists()
+        assert (src / "conflict.txt").read_text() == "src-version"
+        # Destination conflict file untouched
+        assert (dst / "conflict.txt").read_text() == "dst-version"
+        # Non-conflicting file moved to destination
+        assert (dst / "unique.txt").exists()
+        assert (dst / "unique.txt").read_text() == "only-in-src"
+        assert not (src / "unique.txt").exists()
+        # Source directory still exists (has conflicting item)
+        assert src.is_dir()
+
+    def test_move_directory_full_overlap_keeps_all_source(self, tmp_path):
+        """When all items conflict, source dir and all its items are preserved."""
+        src = tmp_path / "src_dir"
+        dst = tmp_path / "dst_dir"
+        src.mkdir()
+        dst.mkdir()
+
+        (src / "a.txt").write_text("src-a")
+        (dst / "a.txt").write_text("dst-a")
+        (src / "b.txt").write_text("src-b")
+        (dst / "b.txt").write_text("dst-b")
+
+        result = _move_directory(src, dst)
+
+        assert result is False
+        # All source items preserved
+        assert (src / "a.txt").read_text() == "src-a"
+        assert (src / "b.txt").read_text() == "src-b"
+        # All destination items untouched
+        assert (dst / "a.txt").read_text() == "dst-a"
+        assert (dst / "b.txt").read_text() == "dst-b"
+
+    def test_move_directory_no_conflict_removes_source(self, tmp_path):
+        """When dst exists but has no overlapping items, source is fully merged and removed."""
+        src = tmp_path / "src_dir"
+        dst = tmp_path / "dst_dir"
+        src.mkdir()
+        dst.mkdir()
+
+        (src / "from_src.txt").write_text("hello")
+        (dst / "already_here.txt").write_text("world")
+
+        result = _move_directory(src, dst)
+
+        assert result is True
+        assert not src.exists()
+        assert (dst / "from_src.txt").read_text() == "hello"
+        assert (dst / "already_here.txt").read_text() == "world"
+
+    def test_migration_conflict_preserves_legacy_and_skips_done_flag(self, migration_env):
+        """migrate_legacy_paths must not mark done when conflicts exist, and must preserve legacy files."""
+        env = migration_env
+
+        # Pre-create destination files with different content
+        data_dir = env["data_dir"]
+        cache_dir = env["cache_dir"]
+        data_dir.mkdir(parents=True)
+        cache_dir.mkdir(parents=True)
+        (data_dir / "history.json").write_text('{"xdg": "new"}')
+
+        mark_done_called = False
+        original_mark = None
+
+        def fake_mark_done():
+            nonlocal mark_done_called
+            mark_done_called = True
+
+        with patch("pyvm_updater.paths.get_data_dir", return_value=data_dir):
+            with patch("pyvm_updater.paths.get_cache_dir", return_value=cache_dir):
+                with patch("pyvm_updater.paths.get_history_file", return_value=data_dir / "history.json"):
+                    with patch("pyvm_updater.paths.get_metadata_db", return_value=cache_dir / "metadata.sqlite"):
+                        with patch(
+                            "pyvm_updater.paths.get_venv_registry_file", return_value=data_dir / "venvs.json"
+                        ):
+                            with patch("pyvm_updater.paths.get_venv_dir", return_value=data_dir / "venvs"):
+                                with patch(
+                                    "pyvm_updater.paths._LEGACY_PATHS",
+                                    {
+                                        "history": env["legacy_history"],
+                                        "metadata": env["legacy_metadata"],
+                                        "venv_dir": env["legacy_pyvm"] / "venvs",
+                                        "venv_registry": env["legacy_pyvm"] / "venvs.json",
+                                        "config_dir": env["home"] / ".config" / "pyvm",
+                                        "config_file": env["home"] / ".config" / "pyvm" / "config.toml",
+                                    },
+                                ):
+                                    with patch("pyvm_updater.paths._migration_done", return_value=False):
+                                        with patch("pyvm_updater.paths._mark_migration_done", side_effect=fake_mark_done):
+                                            migrate_legacy_paths()
+
+        # Legacy history must be preserved (conflict)
+        assert env["legacy_history"].exists()
+        assert env["legacy_history"].read_text() == '[{"action": "install", "version": "3.12.1"}]'
+        # XDG history must be untouched
+        assert (data_dir / "history.json").read_text() == '{"xdg": "new"}'
+        # Migration must NOT be marked as done
+        assert not mark_done_called
 
     def test_migration_handles_missing_legacy_files(self, tmp_path):
         """Test migration gracefully handles non-existent legacy files."""

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,6 +1,5 @@
 """Tests for pyvm_updater.paths module."""
 
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,7 +8,6 @@ import pytest
 from pyvm_updater.paths import (
     get_cache_dir,
     get_config_dir,
-    get_config_file,
     get_data_dir,
     get_history_file,
     get_metadata_db,
@@ -26,7 +24,7 @@ class TestXDGPaths:
     @patch("pyvm_updater.paths._is_windows", return_value=False)
     def test_config_dir_default(self, mock_win):
         """Test default config dir on Linux/macOS."""
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {"HOME": "/home/test", "USERPROFILE": "C:\\Users\\Test"}, clear=True):
             result = get_config_dir()
             assert result == Path.home() / ".config" / "pyvm"
 
@@ -40,7 +38,7 @@ class TestXDGPaths:
     @patch("pyvm_updater.paths._is_windows", return_value=False)
     def test_data_dir_default(self, mock_win):
         """Test default data dir on Linux/macOS."""
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {"HOME": "/home/test", "USERPROFILE": "C:\\Users\\Test"}, clear=True):
             result = get_data_dir()
             assert result == Path.home() / ".local" / "share" / "pyvm"
 
@@ -54,7 +52,7 @@ class TestXDGPaths:
     @patch("pyvm_updater.paths._is_windows", return_value=False)
     def test_cache_dir_default(self, mock_win):
         """Test default cache dir on Linux/macOS."""
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {"HOME": "/home/test", "USERPROFILE": "C:\\Users\\Test"}, clear=True):
             result = get_cache_dir()
             assert result == Path.home() / ".cache" / "pyvm"
 
@@ -82,33 +80,33 @@ class TestConcreteFilePaths:
 
     @patch("pyvm_updater.paths._is_windows", return_value=False)
     def test_history_file(self, mock_win):
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {"HOME": "/home/test", "USERPROFILE": "C:\\Users\\Test"}, clear=True):
             result = get_history_file()
             assert result.name == "history.json"
             assert "pyvm" in str(result)
 
     @patch("pyvm_updater.paths._is_windows", return_value=False)
     def test_metadata_db(self, mock_win):
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {"HOME": "/home/test", "USERPROFILE": "C:\\Users\\Test"}, clear=True):
             result = get_metadata_db()
             assert result.name == "metadata.sqlite"
             assert ".cache" in str(result)
 
     @patch("pyvm_updater.paths._is_windows", return_value=False)
     def test_venv_dir(self, mock_win):
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {"HOME": "/home/test", "USERPROFILE": "C:\\Users\\Test"}, clear=True):
             result = get_venv_dir()
             assert result.name == "venvs"
 
     @patch("pyvm_updater.paths._is_windows", return_value=False)
     def test_venv_registry(self, mock_win):
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {"HOME": "/home/test", "USERPROFILE": "C:\\Users\\Test"}, clear=True):
             result = get_venv_registry_file()
             assert result.name == "venvs.json"
 
     @patch("pyvm_updater.paths._is_windows", return_value=False)
     def test_plugins_dir(self, mock_win):
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {"HOME": "/home/test", "USERPROFILE": "C:\\Users\\Test"}, clear=True):
             result = get_plugins_dir()
             assert result.name == "plugins"
             assert ".config" in str(result)
@@ -159,16 +157,21 @@ class TestMigration:
             with patch("pyvm_updater.paths.get_cache_dir", return_value=env["cache_dir"]):
                 with patch("pyvm_updater.paths.get_history_file", return_value=env["data_dir"] / "history.json"):
                     with patch("pyvm_updater.paths.get_metadata_db", return_value=env["cache_dir"] / "metadata.sqlite"):
-                        with patch("pyvm_updater.paths.get_venv_registry_file", return_value=env["data_dir"] / "venvs.json"):
+                        with patch(
+                            "pyvm_updater.paths.get_venv_registry_file", return_value=env["data_dir"] / "venvs.json"
+                        ):
                             with patch("pyvm_updater.paths.get_venv_dir", return_value=env["data_dir"] / "venvs"):
-                                with patch("pyvm_updater.paths._LEGACY_PATHS", {
-                                    "history": env["legacy_history"],
-                                    "metadata": env["legacy_metadata"],
-                                    "venv_dir": env["legacy_pyvm"] / "venvs",
-                                    "venv_registry": env["legacy_pyvm"] / "venvs.json",
-                                    "config_dir": env["home"] / ".config" / "pyvm",
-                                    "config_file": env["home"] / ".config" / "pyvm" / "config.toml",
-                                }):
+                                with patch(
+                                    "pyvm_updater.paths._LEGACY_PATHS",
+                                    {
+                                        "history": env["legacy_history"],
+                                        "metadata": env["legacy_metadata"],
+                                        "venv_dir": env["legacy_pyvm"] / "venvs",
+                                        "venv_registry": env["legacy_pyvm"] / "venvs.json",
+                                        "config_dir": env["home"] / ".config" / "pyvm",
+                                        "config_file": env["home"] / ".config" / "pyvm" / "config.toml",
+                                    },
+                                ):
                                     with patch("pyvm_updater.paths._migration_done", return_value=False):
                                         with patch("pyvm_updater.paths._mark_migration_done"):
                                             migrate_legacy_paths()
@@ -199,14 +202,17 @@ class TestMigration:
         data_dir = tmp_path / "data" / "pyvm"
 
         with patch("pyvm_updater.paths.get_data_dir", return_value=data_dir):
-            with patch("pyvm_updater.paths._LEGACY_PATHS", {
-                "history": tmp_path / "nonexistent.json",
-                "metadata": tmp_path / "nonexistent.sqlite",
-                "venv_dir": tmp_path / "nonexistent_dir",
-                "venv_registry": tmp_path / "nonexistent_registry.json",
-                "config_dir": tmp_path / "nonexistent_config",
-                "config_file": tmp_path / "nonexistent_config" / "config.toml",
-            }):
+            with patch(
+                "pyvm_updater.paths._LEGACY_PATHS",
+                {
+                    "history": tmp_path / "nonexistent.json",
+                    "metadata": tmp_path / "nonexistent.sqlite",
+                    "venv_dir": tmp_path / "nonexistent_dir",
+                    "venv_registry": tmp_path / "nonexistent_registry.json",
+                    "config_dir": tmp_path / "nonexistent_config",
+                    "config_file": tmp_path / "nonexistent_config" / "config.toml",
+                },
+            ):
                 with patch("pyvm_updater.paths._migration_done", return_value=False):
                     with patch("pyvm_updater.paths._mark_migration_done"):
                         # Should not raise

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,213 @@
+"""Tests for pyvm_updater.paths module."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pyvm_updater.paths import (
+    get_cache_dir,
+    get_config_dir,
+    get_config_file,
+    get_data_dir,
+    get_history_file,
+    get_metadata_db,
+    get_plugins_dir,
+    get_venv_dir,
+    get_venv_registry_file,
+    migrate_legacy_paths,
+)
+
+
+class TestXDGPaths:
+    """Tests for XDG path resolution."""
+
+    @patch("pyvm_updater.paths._is_windows", return_value=False)
+    def test_config_dir_default(self, mock_win):
+        """Test default config dir on Linux/macOS."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = get_config_dir()
+            assert result == Path.home() / ".config" / "pyvm"
+
+    @patch("pyvm_updater.paths._is_windows", return_value=False)
+    def test_config_dir_xdg_override(self, mock_win):
+        """Test config dir respects XDG_CONFIG_HOME."""
+        with patch.dict("os.environ", {"XDG_CONFIG_HOME": "/custom/config"}):
+            result = get_config_dir()
+            assert result == Path("/custom/config/pyvm")
+
+    @patch("pyvm_updater.paths._is_windows", return_value=False)
+    def test_data_dir_default(self, mock_win):
+        """Test default data dir on Linux/macOS."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = get_data_dir()
+            assert result == Path.home() / ".local" / "share" / "pyvm"
+
+    @patch("pyvm_updater.paths._is_windows", return_value=False)
+    def test_data_dir_xdg_override(self, mock_win):
+        """Test data dir respects XDG_DATA_HOME."""
+        with patch.dict("os.environ", {"XDG_DATA_HOME": "/custom/data"}):
+            result = get_data_dir()
+            assert result == Path("/custom/data/pyvm")
+
+    @patch("pyvm_updater.paths._is_windows", return_value=False)
+    def test_cache_dir_default(self, mock_win):
+        """Test default cache dir on Linux/macOS."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = get_cache_dir()
+            assert result == Path.home() / ".cache" / "pyvm"
+
+    @patch("pyvm_updater.paths._is_windows", return_value=False)
+    def test_cache_dir_xdg_override(self, mock_win):
+        """Test cache dir respects XDG_CACHE_HOME."""
+        with patch.dict("os.environ", {"XDG_CACHE_HOME": "/custom/cache"}):
+            result = get_cache_dir()
+            assert result == Path("/custom/cache/pyvm")
+
+    @patch("pyvm_updater.paths._is_windows", return_value=True)
+    def test_windows_uses_localappdata(self, mock_win):
+        """Test Windows paths use LOCALAPPDATA."""
+        with patch.dict("os.environ", {"LOCALAPPDATA": "C:\\Users\\Test\\AppData\\Local"}):
+            config = get_config_dir()
+            data = get_data_dir()
+            cache = get_cache_dir()
+            assert "AppData" in str(config)
+            assert "AppData" in str(data)
+            assert "AppData" in str(cache)
+
+
+class TestConcreteFilePaths:
+    """Tests for concrete file path helpers."""
+
+    @patch("pyvm_updater.paths._is_windows", return_value=False)
+    def test_history_file(self, mock_win):
+        with patch.dict("os.environ", {}, clear=True):
+            result = get_history_file()
+            assert result.name == "history.json"
+            assert "pyvm" in str(result)
+
+    @patch("pyvm_updater.paths._is_windows", return_value=False)
+    def test_metadata_db(self, mock_win):
+        with patch.dict("os.environ", {}, clear=True):
+            result = get_metadata_db()
+            assert result.name == "metadata.sqlite"
+            assert ".cache" in str(result)
+
+    @patch("pyvm_updater.paths._is_windows", return_value=False)
+    def test_venv_dir(self, mock_win):
+        with patch.dict("os.environ", {}, clear=True):
+            result = get_venv_dir()
+            assert result.name == "venvs"
+
+    @patch("pyvm_updater.paths._is_windows", return_value=False)
+    def test_venv_registry(self, mock_win):
+        with patch.dict("os.environ", {}, clear=True):
+            result = get_venv_registry_file()
+            assert result.name == "venvs.json"
+
+    @patch("pyvm_updater.paths._is_windows", return_value=False)
+    def test_plugins_dir(self, mock_win):
+        with patch.dict("os.environ", {}, clear=True):
+            result = get_plugins_dir()
+            assert result.name == "plugins"
+            assert ".config" in str(result)
+
+
+class TestMigration:
+    """Tests for legacy path migration."""
+
+    @pytest.fixture
+    def migration_env(self, tmp_path):
+        """Set up a fake home with legacy files and XDG targets."""
+        home = tmp_path / "home"
+        home.mkdir()
+
+        # Create legacy files
+        legacy_history = home / ".pyvm_history.json"
+        legacy_history.write_text('[{"action": "install", "version": "3.12.1"}]')
+
+        legacy_metadata = home / ".pyvm_metadata.sqlite"
+        legacy_metadata.write_bytes(b"fake sqlite data")
+
+        legacy_pyvm = home / ".pyvm"
+        legacy_pyvm.mkdir()
+        (legacy_pyvm / "venvs.json").write_text('{"myenv": {}}')
+        venvs = legacy_pyvm / "venvs"
+        venvs.mkdir()
+        (venvs / "myenv").mkdir()
+        (venvs / "myenv" / "pyvenv.cfg").write_text("home = /usr/bin")
+
+        # XDG targets
+        data_dir = tmp_path / "data" / "pyvm"
+        cache_dir = tmp_path / "cache" / "pyvm"
+
+        return {
+            "home": home,
+            "data_dir": data_dir,
+            "cache_dir": cache_dir,
+            "legacy_history": legacy_history,
+            "legacy_metadata": legacy_metadata,
+            "legacy_pyvm": legacy_pyvm,
+        }
+
+    def test_migration_moves_files(self, migration_env):
+        """Test that migration moves legacy files to XDG locations."""
+        env = migration_env
+
+        with patch("pyvm_updater.paths.get_data_dir", return_value=env["data_dir"]):
+            with patch("pyvm_updater.paths.get_cache_dir", return_value=env["cache_dir"]):
+                with patch("pyvm_updater.paths.get_history_file", return_value=env["data_dir"] / "history.json"):
+                    with patch("pyvm_updater.paths.get_metadata_db", return_value=env["cache_dir"] / "metadata.sqlite"):
+                        with patch("pyvm_updater.paths.get_venv_registry_file", return_value=env["data_dir"] / "venvs.json"):
+                            with patch("pyvm_updater.paths.get_venv_dir", return_value=env["data_dir"] / "venvs"):
+                                with patch("pyvm_updater.paths._LEGACY_PATHS", {
+                                    "history": env["legacy_history"],
+                                    "metadata": env["legacy_metadata"],
+                                    "venv_dir": env["legacy_pyvm"] / "venvs",
+                                    "venv_registry": env["legacy_pyvm"] / "venvs.json",
+                                    "config_dir": env["home"] / ".config" / "pyvm",
+                                    "config_file": env["home"] / ".config" / "pyvm" / "config.toml",
+                                }):
+                                    with patch("pyvm_updater.paths._migration_done", return_value=False):
+                                        with patch("pyvm_updater.paths._mark_migration_done"):
+                                            migrate_legacy_paths()
+
+        # Verify files moved
+        assert (env["data_dir"] / "history.json").exists()
+        assert (env["cache_dir"] / "metadata.sqlite").exists()
+        assert (env["data_dir"] / "venvs.json").exists()
+        assert (env["data_dir"] / "venvs" / "myenv" / "pyvenv.cfg").exists()
+
+        # Verify old files are gone
+        assert not env["legacy_history"].exists()
+        assert not env["legacy_metadata"].exists()
+
+    def test_migration_skips_if_already_done(self, migration_env):
+        """Test that migration doesn't run twice."""
+        env = migration_env
+
+        with patch("pyvm_updater.paths._migration_done", return_value=True):
+            migrate_legacy_paths()
+
+        # Legacy files should still exist (not moved)
+        assert env["legacy_history"].exists()
+        assert env["legacy_metadata"].exists()
+
+    def test_migration_handles_missing_legacy_files(self, tmp_path):
+        """Test migration gracefully handles non-existent legacy files."""
+        data_dir = tmp_path / "data" / "pyvm"
+
+        with patch("pyvm_updater.paths.get_data_dir", return_value=data_dir):
+            with patch("pyvm_updater.paths._LEGACY_PATHS", {
+                "history": tmp_path / "nonexistent.json",
+                "metadata": tmp_path / "nonexistent.sqlite",
+                "venv_dir": tmp_path / "nonexistent_dir",
+                "venv_registry": tmp_path / "nonexistent_registry.json",
+                "config_dir": tmp_path / "nonexistent_config",
+                "config_file": tmp_path / "nonexistent_config" / "config.toml",
+            }):
+                with patch("pyvm_updater.paths._migration_done", return_value=False):
+                    with patch("pyvm_updater.paths._mark_migration_done"):
+                        # Should not raise
+                        migrate_legacy_paths()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -295,7 +295,6 @@ class TestMigration:
         (data_dir / "history.json").write_text('{"xdg": "new"}')
 
         mark_done_called = False
-        original_mark = None
 
         def fake_mark_done():
             nonlocal mark_done_called
@@ -305,9 +304,7 @@ class TestMigration:
             with patch("pyvm_updater.paths.get_cache_dir", return_value=cache_dir):
                 with patch("pyvm_updater.paths.get_history_file", return_value=data_dir / "history.json"):
                     with patch("pyvm_updater.paths.get_metadata_db", return_value=cache_dir / "metadata.sqlite"):
-                        with patch(
-                            "pyvm_updater.paths.get_venv_registry_file", return_value=data_dir / "venvs.json"
-                        ):
+                        with patch("pyvm_updater.paths.get_venv_registry_file", return_value=data_dir / "venvs.json"):
                             with patch("pyvm_updater.paths.get_venv_dir", return_value=data_dir / "venvs"):
                                 with patch(
                                     "pyvm_updater.paths._LEGACY_PATHS",
@@ -321,7 +318,9 @@ class TestMigration:
                                     },
                                 ):
                                     with patch("pyvm_updater.paths._migration_done", return_value=False):
-                                        with patch("pyvm_updater.paths._mark_migration_done", side_effect=fake_mark_done):
+                                        with patch(
+                                            "pyvm_updater.paths._mark_migration_done", side_effect=fake_mark_done
+                                        ):
                                             migrate_legacy_paths()
 
         # Legacy history must be preserved (conflict)


### PR DESCRIPTION
Moves data files from `$HOME` to proper XDG directories:
fixes #76  

| Before | After |
|--------|-------|
| `~/.pyvm_history.json` | `~/.local/share/pyvm/history.json` |
| `~/.pyvm_metadata.sqlite` | `~/.cache/pyvm/metadata.sqlite` |
| `~/.pyvm/venvs/` | `~/.local/share/pyvm/venvs/` |
| `~/.pyvm/venvs.json` | `~/.local/share/pyvm/venvs.json` |
 
On Windows everything goes to `%LOCALAPPDATA%/pyvm/`.
 
Existing files are automatically migrated on first run. Migration only runs once and logs what it moved.
 
Also respects `XDG_*_HOME` env vars if set.
 
**Testing:** All 64 tests pass, including 15 new ones for path resolution and migration.

GSSoC26