### PR TITLE
feat: add --json output flag to check, list, and info commands

### DIFF
--- a/src/pyvm_updater/cli.py
+++ b/src/pyvm_updater/cli.py
@@ -119,10 +119,20 @@ def rollback(yes: bool) -> None:
 
 
 @cli.command()
-def check() -> None:
+@click.option("--json", "output_json", is_flag=True, help="Output result as JSON")
+def check(output_json: bool) -> None:
     """Check current Python version against latest stable release."""
     try:
-        _local_ver, _latest_ver, needs_update = check_python_version(silent=False)
+        _local_ver, _latest_ver, needs_update = check_python_version(silent=output_json)
+
+        if output_json:
+            data = {
+                "local_version": _local_ver,
+                "latest_version": _latest_ver,
+                "update_available": needs_update,
+            }
+            click.echo(json.dumps(data, indent=2))
+            sys.exit(0)
 
         if needs_update:
             click.echo("\n💡 Tip: Run 'pyvm update' to upgrade Python")
@@ -267,10 +277,12 @@ def remove(version: str, dry_run: bool, yes: bool) -> None:
     is_flag=True,
     help="Show all versions including patch releases",
 )
-def list_versions(show_all: bool) -> None:
+@click.option("--json", "output_json", is_flag=True, help="Output result as JSON")
+def list_versions(show_all: bool, output_json: bool) -> None:
     """List available Python versions."""
     try:
-        click.echo("Fetching Python versions...\n")
+        if not output_json:
+            click.echo("Fetching Python versions...\n")
 
         local_ver = platform.python_version()
         local_series = ".".join(local_ver.split(".")[:2])
@@ -278,10 +290,29 @@ def list_versions(show_all: bool) -> None:
         if show_all:
             versions = get_available_python_versions(limit=100)
             if not versions:
-                click.echo("Could not fetch available versions.")
+                if output_json:
+                    click.echo(json.dumps({"error": "Could not fetch available versions."}, indent=2))
+                else:
+                    click.echo("Could not fetch available versions.")
                 sys.exit(1)
 
             latest_ver, _ = get_latest_python_info_with_retry()
+
+            if output_json:
+                data = {
+                    "local_version": local_ver,
+                    "latest_version": latest_ver,
+                    "versions": [
+                        {
+                            "version": v["version"],
+                            "installed": v["version"] == local_ver,
+                            "latest": latest_ver and v["version"] == latest_ver,
+                        }
+                        for v in versions
+                    ],
+                }
+                click.echo(json.dumps(data, indent=2))
+                return
 
             click.echo(f"{'VERSION':<12} {'STATUS'}")
             click.echo("-" * 40)
@@ -297,8 +328,28 @@ def list_versions(show_all: bool) -> None:
         else:
             releases = get_active_python_releases()
             if not releases:
-                click.echo("Could not fetch active releases.")
+                if output_json:
+                    click.echo(json.dumps({"error": "Could not fetch active releases."}, indent=2))
+                else:
+                    click.echo("Could not fetch active releases.")
                 sys.exit(1)
+
+            if output_json:
+                data = {
+                    "local_version": local_ver,
+                    "releases": [
+                        {
+                            "series": rel["series"],
+                            "latest_version": rel.get("latest_version"),
+                            "status": rel.get("status", ""),
+                            "end_of_support": rel.get("end_of_support", ""),
+                            "installed": rel["series"] == local_series,
+                        }
+                        for rel in releases
+                    ],
+                }
+                click.echo(json.dumps(data, indent=2))
+                return
 
             click.echo(f"{'SERIES':<10} {'LATEST':<12} {'STATUS':<15} {'SUPPORT UNTIL'}")
             click.echo("-" * 55)
@@ -431,30 +482,47 @@ def tui() -> None:
 
 
 @cli.command()
-def info() -> None:
+@click.option("--json", "output_json", is_flag=True, help="Output result as JSON")
+def info(output_json: bool) -> None:
     """Show detailed system and Python information."""
     try:
-        click.echo("=" * 50)
-        click.echo("           System Information")
-        click.echo("=" * 50)
-
         os_name, arch = get_os_info()
-        click.echo(f"Operating System: {os_name.title()}")
-        click.echo(f"Architecture:     {arch}")
-        click.echo(f"Python Version:   {platform.python_version()}")
-        click.echo(f"Python Path:      {sys.executable}")
-        click.echo(f"Platform:         {platform.platform()}")
-        click.echo(f"\nAdmin/Sudo:       {'Yes' if is_admin() else 'No'}")
 
+        info_data = {
+            "os": os_name,
+            "architecture": arch,
+            "python_version": platform.python_version(),
+            "python_path": sys.executable,
+            "platform": platform.platform(),
+            "admin": is_admin(),
+        }
+
+        # Try to find python3 path
         try:
-            result = subprocess.run(["which", "python3"], capture_output=True, text=True, check=False)
+            which_cmd = "where" if os_name == "windows" else "which"
+            result = subprocess.run([which_cmd, "python3"], capture_output=True, text=True, check=False)
             if result.returncode == 0:
-                python3_path = result.stdout.strip()
+                python3_path = result.stdout.strip().split("\n")[0]
                 if python3_path != sys.executable:
-                    click.echo(f"python3 command:  {python3_path}")
+                    info_data["python3_path"] = python3_path
         except Exception:
             pass
 
+        if output_json:
+            click.echo(json.dumps(info_data, indent=2))
+            return
+
+        click.echo("=" * 50)
+        click.echo("           System Information")
+        click.echo("=" * 50)
+        click.echo(f"Operating System: {os_name.title()}")
+        click.echo(f"Architecture:     {arch}")
+        click.echo(f"Python Version:   {info_data['python_version']}")
+        click.echo(f"Python Path:      {info_data['python_path']}")
+        click.echo(f"Platform:         {info_data['platform']}")
+        click.echo(f"\nAdmin/Sudo:       {'Yes' if info_data['admin'] else 'No'}")
+        if "python3_path" in info_data:
+            click.echo(f"python3 command:  {info_data['python3_path']}")
         click.echo("=" * 50)
 
     except Exception as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,13 @@
 import pytest
 from click.testing import CliRunner
+
 from pyvm_updater.cli import cli
+
 
 @pytest.fixture
 def runner():
     return CliRunner()
+
 
 def test_install_dry_run(runner):
     """Verify that the install dry-run flag prints the correct message and exits 0."""
@@ -12,6 +15,7 @@ def test_install_dry_run(runner):
     assert result.exit_code == 0
     assert "[DRY-RUN]" in result.output
     assert "Would download and install Python 3.12.1" in result.output
+
 
 def test_remove_dry_run(runner):
     """Verify that the remove dry-run flag prints the correct message and exits 0."""

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -1,0 +1,110 @@
+"""Tests for --json output flag on check, list, and info commands."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from pyvm_updater.cli import cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestCheckJson:
+    """Tests for pyvm check --json."""
+
+    @patch("pyvm_updater.cli.check_python_version")
+    def test_check_json_output_is_valid(self, mock_check, runner):
+        mock_check.return_value = ("3.12.1", "3.13.0", True)
+        result = runner.invoke(cli, ["check", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["local_version"] == "3.12.1"
+        assert data["latest_version"] == "3.13.0"
+        assert data["update_available"] is True
+
+    @patch("pyvm_updater.cli.check_python_version")
+    def test_check_json_no_update(self, mock_check, runner):
+        mock_check.return_value = ("3.13.0", "3.13.0", False)
+        result = runner.invoke(cli, ["check", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["update_available"] is False
+
+    @patch("pyvm_updater.cli.check_python_version")
+    def test_check_json_network_failure(self, mock_check, runner):
+        mock_check.return_value = ("3.12.1", None, False)
+        result = runner.invoke(cli, ["check", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["latest_version"] is None
+        assert data["update_available"] is False
+
+
+class TestInfoJson:
+    """Tests for pyvm info --json."""
+
+    def test_info_json_output_is_valid(self, runner):
+        result = runner.invoke(cli, ["info", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "os" in data
+        assert "architecture" in data
+        assert "python_version" in data
+        assert "python_path" in data
+        assert "platform" in data
+        assert "admin" in data
+
+    def test_info_json_types(self, runner):
+        result = runner.invoke(cli, ["info", "--json"])
+        data = json.loads(result.output)
+        assert isinstance(data["os"], str)
+        assert isinstance(data["admin"], bool)
+
+
+class TestListJson:
+    """Tests for pyvm list --json."""
+
+    @patch("pyvm_updater.cli.get_active_python_releases")
+    def test_list_json_releases(self, mock_releases, runner):
+        mock_releases.return_value = [
+            {
+                "series": "3.13",
+                "latest_version": "3.13.0",
+                "status": "bugfix",
+                "end_of_support": "2029-10",
+            },
+            {
+                "series": "3.12",
+                "latest_version": "3.12.7",
+                "status": "security",
+                "end_of_support": "2028-10",
+            },
+        ]
+        result = runner.invoke(cli, ["list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "local_version" in data
+        assert "releases" in data
+        assert len(data["releases"]) == 2
+        assert data["releases"][0]["series"] == "3.13"
+
+    @patch("pyvm_updater.cli.get_available_python_versions")
+    @patch("pyvm_updater.cli.get_latest_python_info_with_retry")
+    def test_list_all_json(self, mock_latest, mock_versions, runner):
+        mock_versions.return_value = [
+            {"version": "3.13.0"},
+            {"version": "3.12.7"},
+        ]
+        mock_latest.return_value = ("3.13.0", "https://example.com")
+        result = runner.invoke(cli, ["list", "--all", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "versions" in data
+        assert len(data["versions"]) == 2
+        assert data["versions"][0]["version"] == "3.13.0"
+        assert data["versions"][0]["latest"] is True


### PR DESCRIPTION
closes #51 

Adds `--json` to the three commands most useful for scripting:
- pyvm check --json
- pyvm list --json
- pyvm list --all --json
- pyvm info --json
<img width="935" height="284" alt="image" src="https://github.com/user-attachments/assets/53777240-bcd3-48e0-aaa1-2c033cf5577b" />
---

Each command returns clean JSON to stdout so the output can be piped into `jq`, shell scripts, or any automation tool without parsing human-readable text.

Also fixes a crash on Windows in the [info](cci:1://file://wsl.localhost/kali-linux/home/fsociety/fcc/pyvm-updater/src/pyvm_updater/cli.py:483:0-529:19) command where `which` was being called instead of `where`.

**Testing:** 7 new tests added, all 56 pass.

GSSoC26