### PR TITLE
feat: add pyvm venv rename command

### DIFF
--- a/src/pyvm_updater/cli.py
+++ b/src/pyvm_updater/cli.py
@@ -658,7 +658,7 @@ def venv_remove(name: str, yes: bool) -> None:
 
         venv_path = get_venv_dir() / name
         if not venv_path.exists():
-            click.echo(f"❌ Venv '{name}' not found.")
+            click.echo(f"[X] Venv '{name}' not found.")
             sys.exit(1)
 
     if not yes:
@@ -687,7 +687,7 @@ def venv_activate(name: str) -> None:
         click.echo(f"To activate '{name}':")
         click.echo(f"\n  {activate_cmd}\n")
     else:
-        click.echo(f"❌ Venv '{name}' not found.")
+        click.echo(f"[X] Venv '{name}' not found.")
         sys.exit(1)
 
 

--- a/src/pyvm_updater/cli.py
+++ b/src/pyvm_updater/cli.py
@@ -691,6 +691,27 @@ def venv_activate(name: str) -> None:
         sys.exit(1)
 
 
+@venv.command("rename")
+@click.argument("old_name")
+@click.argument("new_name")
+def venv_rename(old_name: str, new_name: str) -> None:
+    """Rename a virtual environment.
+
+    Moves the venv folder on disk and updates the internal registry.
+
+    Example: pyvm venv rename old-project new-project
+    """
+    from .venv import rename_venv
+
+    success, message = rename_venv(old_name, new_name)
+
+    if success:
+        click.echo(f"[OK] {message}")
+    else:
+        click.echo(f"[X] {message}")
+        sys.exit(1)
+
+
 @cli.command()
 def doctor():
     """Run a health check of the environment."""

--- a/src/pyvm_updater/venv.py
+++ b/src/pyvm_updater/venv.py
@@ -46,6 +46,7 @@ def save_venv_registry(registry: dict[str, Any]) -> None:
             json.dump(registry, f, indent=2)
     except OSError as e:
         log.warning(f"Could not save venv registry: {e}")
+        raise
 
 
 def find_python_executable(version: str) -> str | None:
@@ -299,6 +300,46 @@ def remove_venv(name: str, force: bool = False) -> tuple[bool, str]:
         return False, f"Failed to remove venv: {e}"
 
 
+def _fix_venv_paths(venv_path: Path, old_path: Path) -> None:
+    """Fix hardcoded paths inside a venv so it points to its new location."""
+    old_str = str(old_path)
+    new_str = str(venv_path)
+
+    # Fix pyvenv.cfg
+    cfg = venv_path / "pyvenv.cfg"
+    if cfg.exists():
+        try:
+            t = cfg.read_text(encoding="utf-8")
+            cfg.write_text(t.replace(old_str, new_str), encoding="utf-8")
+        except OSError:
+            pass
+
+    # Fix all scripts in bin/Scripts (activation scripts, pip, wrappers, etc.)
+    for scripts_dir in [venv_path / "bin", venv_path / "Scripts"]:
+        if not scripts_dir.exists():
+            continue
+
+        for script in scripts_dir.iterdir():
+            if not script.is_file():
+                continue
+
+            try:
+                # Try to process as text first
+                try:
+                    t = script.read_text(encoding="utf-8")
+                    if old_str in t:
+                        script.write_text(t.replace(old_str, new_str), encoding="utf-8")
+                except UnicodeDecodeError:
+                    # Fallback for binary wrappers
+                    b = script.read_bytes()
+                    old_bytes = old_str.encode("utf-8")
+                    new_bytes = new_str.encode("utf-8")
+                    if old_bytes in b:
+                        script.write_bytes(b.replace(old_bytes, new_bytes))
+            except OSError:
+                pass
+
+
 def rename_venv(old_name: str, new_name: str) -> tuple[bool, str]:
     """Rename a virtual environment on disk and in the registry.
 
@@ -322,17 +363,20 @@ def rename_venv(old_name: str, new_name: str) -> tuple[bool, str]:
         return False, f"Venv '{old_name}' not found"
 
     # Check new name is not taken
-    new_path = get_venv_dir() / new_name
+    new_path = old_path.parent / new_name
     if new_name in registry:
         return False, f"Venv '{new_name}' already exists in registry"
     if new_path.exists():
         return False, f"Directory '{new_path}' already exists"
 
+    disk_moved = False
     try:
         # Move the folder on disk if it exists
         if old_path.exists():
             new_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(old_path), str(new_path))
+            disk_moved = True
+            _fix_venv_paths(new_path, old_path)
 
         # Update registry
         if old_name in registry:
@@ -345,7 +389,15 @@ def rename_venv(old_name: str, new_name: str) -> tuple[bool, str]:
                 "path": str(new_path),
                 "python_version": "unknown",
             }
-        save_venv_registry(registry)
+
+        try:
+            save_venv_registry(registry)
+        except OSError as e:
+            # Rollback disk rename
+            if disk_moved:
+                shutil.move(str(new_path), str(old_path))
+                _fix_venv_paths(old_path, new_path)
+            return False, f"Failed to save registry, rename rolled back: {e}"
 
         return True, f"Renamed venv '{old_name}' to '{new_name}'"
 

--- a/src/pyvm_updater/venv.py
+++ b/src/pyvm_updater/venv.py
@@ -202,7 +202,7 @@ def create_venv(
                 error_output = e.stderr or e.stdout
                 return (
                     True,
-                    f"{success_msg}\n   ⚠️ Warning: Failed to install requirements from {requirements_file.name}:\n"
+                    f"{success_msg}\n   [!] Warning: Failed to install requirements from {requirements_file.name}:\n"
                     f"{error_output}",
                 )
 

--- a/src/pyvm_updater/venv.py
+++ b/src/pyvm_updater/venv.py
@@ -299,6 +299,60 @@ def remove_venv(name: str, force: bool = False) -> tuple[bool, str]:
         return False, f"Failed to remove venv: {e}"
 
 
+def rename_venv(old_name: str, new_name: str) -> tuple[bool, str]:
+    """Rename a virtual environment on disk and in the registry.
+
+    Args:
+        old_name: Current name of the venv.
+        new_name: Desired new name for the venv.
+
+    Returns:
+        Tuple of (success, message).
+    """
+    registry = get_venv_registry()
+
+    # Resolve old venv path
+    if old_name in registry:
+        old_path = Path(registry[old_name].get("path", ""))
+    else:
+        old_path = get_venv_dir() / old_name
+
+    # Check old venv exists (on disk or in registry)
+    if old_name not in registry and not old_path.exists():
+        return False, f"Venv '{old_name}' not found"
+
+    # Check new name is not taken
+    new_path = get_venv_dir() / new_name
+    if new_name in registry:
+        return False, f"Venv '{new_name}' already exists in registry"
+    if new_path.exists():
+        return False, f"Directory '{new_path}' already exists"
+
+    try:
+        # Move the folder on disk if it exists
+        if old_path.exists():
+            new_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(old_path), str(new_path))
+
+        # Update registry
+        if old_name in registry:
+            entry = registry.pop(old_name)
+            entry["path"] = str(new_path)
+            registry[new_name] = entry
+        else:
+            # Unregistered venv on disk, create a registry entry
+            registry[new_name] = {
+                "path": str(new_path),
+                "python_version": "unknown",
+            }
+        save_venv_registry(registry)
+
+        return True, f"Renamed venv '{old_name}' to '{new_name}'"
+
+    except OSError as e:
+        return False, f"Failed to rename venv: {e}"
+
+
 def get_venv_activate_command(name: str) -> str | None:
     """Get the command to activate a venv.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,13 @@
 import pytest
 from click.testing import CliRunner
+
 from pyvm_updater.cli import cli
+
 
 @pytest.fixture
 def runner():
     return CliRunner()
+
 
 def test_install_dry_run(runner):
     """Verify that the install dry-run flag prints the correct message and exits 0."""
@@ -12,6 +15,7 @@ def test_install_dry_run(runner):
     assert result.exit_code == 0
     assert "[DRY-RUN]" in result.output
     assert "Would download and install Python 3.12.1" in result.output
+
 
 def test_remove_dry_run(runner):
     """Verify that the remove dry-run flag prints the correct message and exits 0."""

--- a/tests/test_venv_rename.py
+++ b/tests/test_venv_rename.py
@@ -161,3 +161,88 @@ class TestRenameVenv:
 
         reg = json.loads(registry_file.read_text())
         assert "adopted" in reg
+
+    def test_rename_custom_path(self, venv_dir, tmp_path):
+        """Rename should preserve the custom parent directory."""
+        venvs, registry_file = venv_dir
+        custom_parent = tmp_path / "custom"
+        custom_parent.mkdir()
+        old_path = _make_fake_venv(custom_parent, "custom-old")
+
+        registry = {"custom-old": {"path": str(old_path), "python_version": "3.12"}}
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        with (
+            patch(list(patches.keys())[0], patches[list(patches.keys())[0]]),
+            patch(list(patches.keys())[1], patches[list(patches.keys())[1]]),
+        ):
+            success, msg = rename_venv("custom-old", "custom-new")
+
+        assert success is True
+        assert not old_path.exists()
+        new_path = custom_parent / "custom-new"
+        assert new_path.exists()
+
+        reg = json.loads(registry_file.read_text())
+        assert "custom-old" not in reg
+        assert "custom-new" in reg
+        assert reg["custom-new"]["path"] == str(new_path)
+
+    def test_rename_fixes_script_wrappers(self, venv_dir):
+        """Scripts like pip should have their shebang/path updated."""
+        venvs, registry_file = venv_dir
+        source_path = _make_fake_venv(venvs, "original")
+
+        # Make a fake pip script
+        bin_dir = source_path / "bin"
+        pip_script = bin_dir / "pip"
+        pip_script.write_text(f"#!{source_path}/bin/python\nprint('pip')")
+
+        # Make a fake binary executable (like pip.exe)
+        pip_exe = bin_dir / "pip.exe"
+        old_bytes = str(source_path).encode("utf-8")
+        pip_exe.write_bytes(b"PK\x03\x04" + old_bytes + b"\x00\x01")
+
+        registry = {"original": {"path": str(source_path), "python_version": "3.13"}}
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        with (
+            patch(list(patches.keys())[0], patches[list(patches.keys())[0]]),
+            patch(list(patches.keys())[1], patches[list(patches.keys())[1]]),
+        ):
+            success, msg = rename_venv("original", "renamed")
+
+        assert success is True
+
+        new_pip = venvs / "renamed" / "bin" / "pip"
+        assert str(venvs / "renamed") in new_pip.read_text()
+        assert str(venvs / "original") not in new_pip.read_text()
+
+        new_pip_exe = venvs / "renamed" / "bin" / "pip.exe"
+        assert str(venvs / "renamed").encode("utf-8") in new_pip_exe.read_bytes()
+        assert str(venvs / "original").encode("utf-8") not in new_pip_exe.read_bytes()
+
+    def test_rename_registry_failure_rollback(self, venv_dir):
+        """If save_venv_registry fails, disk move should be rolled back."""
+        venvs, registry_file = venv_dir
+        old_path = _make_fake_venv(venvs, "old-project")
+
+        registry = {"old-project": {"path": str(old_path), "python_version": "3.13"}}
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        with (
+            patch(list(patches.keys())[0], patches[list(patches.keys())[0]]),
+            patch(list(patches.keys())[1], patches[list(patches.keys())[1]]),
+            patch("pyvm_updater.venv.save_venv_registry", side_effect=OSError("Disk full")),
+        ):
+            success, msg = rename_venv("old-project", "new-project")
+
+        assert success is False
+        assert "rolled back" in msg
+
+        # Disk: rollback happened
+        assert old_path.exists()
+        assert not (venvs / "new-project").exists()

--- a/tests/test_venv_rename.py
+++ b/tests/test_venv_rename.py
@@ -1,0 +1,152 @@
+"""Tests for pyvm venv rename command."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pyvm_updater.venv import rename_venv
+
+
+@pytest.fixture
+def venv_dir(tmp_path):
+    """Create a temporary venv directory and registry."""
+    venvs = tmp_path / "venvs"
+    venvs.mkdir()
+    registry_file = tmp_path / "venvs.json"
+    return venvs, registry_file
+
+
+def _make_fake_venv(venv_dir, name):
+    """Create a fake venv directory with an activate script."""
+    venv_path = venv_dir / name
+    (venv_path / "bin").mkdir(parents=True)
+    (venv_path / "bin" / "activate").touch()
+    return venv_path
+
+
+def _patch_venv(venv_dir, registry_file):
+    """Return a dict of patches for venv module globals."""
+    return {
+        "pyvm_updater.venv.get_venv_dir": lambda: venv_dir,
+        "pyvm_updater.venv.VENV_REGISTRY": registry_file,
+    }
+
+
+class TestRenameVenv:
+
+    def test_rename_registered_venv(self, venv_dir):
+        venvs, registry_file = venv_dir
+        old_path = _make_fake_venv(venvs, "old-project")
+
+        registry = {
+            "old-project": {
+                "path": str(old_path),
+                "python_version": "3.13",
+                "python_executable": "/usr/bin/python",
+            }
+        }
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
+             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+            success, msg = rename_venv("old-project", "new-project")
+
+        assert success is True
+        assert "Renamed" in msg
+
+        # Disk: old gone, new exists
+        assert not (venvs / "old-project").exists()
+        assert (venvs / "new-project").exists()
+
+        # Registry updated
+        reg = json.loads(registry_file.read_text())
+        assert "old-project" not in reg
+        assert "new-project" in reg
+        assert reg["new-project"]["python_version"] == "3.13"
+        assert "new-project" in reg["new-project"]["path"]
+
+    def test_rename_old_not_found(self, venv_dir):
+        venvs, registry_file = venv_dir
+        registry_file.write_text("{}")
+
+        patches = _patch_venv(venvs, registry_file)
+        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
+             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+            success, msg = rename_venv("ghost", "new-name")
+
+        assert success is False
+        assert "not found" in msg
+
+    def test_rename_new_name_already_in_registry(self, venv_dir):
+        venvs, registry_file = venv_dir
+        _make_fake_venv(venvs, "aaa")
+
+        registry = {
+            "aaa": {"path": str(venvs / "aaa"), "python_version": "3.12"},
+            "bbb": {"path": str(venvs / "bbb"), "python_version": "3.12"},
+        }
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
+             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+            success, msg = rename_venv("aaa", "bbb")
+
+        assert success is False
+        assert "already exists" in msg
+
+    def test_rename_new_dir_already_exists(self, venv_dir):
+        venvs, registry_file = venv_dir
+        _make_fake_venv(venvs, "aaa")
+        _make_fake_venv(venvs, "bbb")
+
+        registry = {"aaa": {"path": str(venvs / "aaa"), "python_version": "3.12"}}
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
+             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+            success, msg = rename_venv("aaa", "bbb")
+
+        assert success is False
+        assert "already exists" in msg
+
+    def test_rename_stale_registry_entry(self, venv_dir):
+        """Registry entry exists but folder is gone -- just update registry."""
+        venvs, registry_file = venv_dir
+
+        registry = {
+            "stale": {"path": str(venvs / "stale"), "python_version": "3.11"},
+        }
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
+             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+            success, msg = rename_venv("stale", "fresh")
+
+        assert success is True
+        reg = json.loads(registry_file.read_text())
+        assert "stale" not in reg
+        assert "fresh" in reg
+
+    def test_rename_unregistered_venv_on_disk(self, venv_dir):
+        """Folder exists but not in registry -- move and register."""
+        venvs, registry_file = venv_dir
+        _make_fake_venv(venvs, "orphan")
+        registry_file.write_text("{}")
+
+        patches = _patch_venv(venvs, registry_file)
+        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
+             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+            success, msg = rename_venv("orphan", "adopted")
+
+        assert success is True
+        assert not (venvs / "orphan").exists()
+        assert (venvs / "adopted").exists()
+
+        reg = json.loads(registry_file.read_text())
+        assert "adopted" in reg

--- a/tests/test_venv_rename.py
+++ b/tests/test_venv_rename.py
@@ -1,7 +1,6 @@
 """Tests for pyvm venv rename command."""
 
 import json
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -50,8 +49,10 @@ class TestRenameVenv:
         registry_file.write_text(json.dumps(registry))
 
         patches = _patch_venv(venvs, registry_file)
-        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
-             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+        with (
+            patch(list(patches.keys())[0], patches[list(patches.keys())[0]]),
+            patch(list(patches.keys())[1], patches[list(patches.keys())[1]]),
+        ):
             success, msg = rename_venv("old-project", "new-project")
 
         assert success is True
@@ -73,8 +74,10 @@ class TestRenameVenv:
         registry_file.write_text("{}")
 
         patches = _patch_venv(venvs, registry_file)
-        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
-             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+        with (
+            patch(list(patches.keys())[0], patches[list(patches.keys())[0]]),
+            patch(list(patches.keys())[1], patches[list(patches.keys())[1]]),
+        ):
             success, msg = rename_venv("ghost", "new-name")
 
         assert success is False
@@ -91,8 +94,10 @@ class TestRenameVenv:
         registry_file.write_text(json.dumps(registry))
 
         patches = _patch_venv(venvs, registry_file)
-        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
-             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+        with (
+            patch(list(patches.keys())[0], patches[list(patches.keys())[0]]),
+            patch(list(patches.keys())[1], patches[list(patches.keys())[1]]),
+        ):
             success, msg = rename_venv("aaa", "bbb")
 
         assert success is False
@@ -107,8 +112,10 @@ class TestRenameVenv:
         registry_file.write_text(json.dumps(registry))
 
         patches = _patch_venv(venvs, registry_file)
-        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
-             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+        with (
+            patch(list(patches.keys())[0], patches[list(patches.keys())[0]]),
+            patch(list(patches.keys())[1], patches[list(patches.keys())[1]]),
+        ):
             success, msg = rename_venv("aaa", "bbb")
 
         assert success is False
@@ -124,8 +131,10 @@ class TestRenameVenv:
         registry_file.write_text(json.dumps(registry))
 
         patches = _patch_venv(venvs, registry_file)
-        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
-             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+        with (
+            patch(list(patches.keys())[0], patches[list(patches.keys())[0]]),
+            patch(list(patches.keys())[1], patches[list(patches.keys())[1]]),
+        ):
             success, msg = rename_venv("stale", "fresh")
 
         assert success is True
@@ -140,8 +149,10 @@ class TestRenameVenv:
         registry_file.write_text("{}")
 
         patches = _patch_venv(venvs, registry_file)
-        with patch(list(patches.keys())[0], patches[list(patches.keys())[0]]), \
-             patch(list(patches.keys())[1], patches[list(patches.keys())[1]]):
+        with (
+            patch(list(patches.keys())[0], patches[list(patches.keys())[0]]),
+            patch(list(patches.keys())[1], patches[list(patches.keys())[1]]),
+        ):
             success, msg = rename_venv("orphan", "adopted")
 
         assert success is True


### PR DESCRIPTION
Adds `pyvm venv rename <old> <new>` to safely rename virtual environments.
 
Moves the venv folder on disk and updates the internal JSON registry atomically, avoiding the broken state that manual renaming causes.

- Handles registered venvs, unregistered venvs, and stale registry entries
- Validates old name exists and new name is not taken
- 6 tests covering all rename scenarios

Closes #84

<img width="1459" height="536" alt="image" src="https://github.com/user-attachments/assets/62709b21-941f-4ebc-ba79-c22333c6b649" />

GSSoC26