### PR TITLE
feat: add pyvm venv duplicate command

### DIFF
--- a/src/pyvm_updater/cli.py
+++ b/src/pyvm_updater/cli.py
@@ -691,6 +691,28 @@ def venv_activate(name: str) -> None:
         sys.exit(1)
 
 
+@venv.command("duplicate")
+@click.argument("source_name")
+@click.argument("new_name")
+def venv_duplicate(source_name: str, new_name: str) -> None:
+    """Duplicate a virtual environment.
+
+    Copies the venv folder and fixes internal paths so the clone works
+    independently of the original.
+
+    Example: pyvm venv duplicate base-env experimental-env
+    """
+    from .venv import duplicate_venv
+
+    success, message = duplicate_venv(source_name, new_name)
+
+    if success:
+        click.echo(f"[OK] {message}")
+    else:
+        click.echo(f"[X] {message}")
+        sys.exit(1)
+
+
 @cli.command()
 def doctor():
     """Run a health check of the environment."""

--- a/src/pyvm_updater/venv.py
+++ b/src/pyvm_updater/venv.py
@@ -313,24 +313,33 @@ def _fix_venv_paths(venv_path: Path, old_path: Path) -> None:
     cfg = venv_path / "pyvenv.cfg"
     if cfg.exists():
         try:
-            t = cfg.read_text()
-            cfg.write_text(t.replace(old_str, new_str))
+            t = cfg.read_text(encoding="utf-8")
+            cfg.write_text(t.replace(old_str, new_str), encoding="utf-8")
         except OSError:
             pass
 
-    # Fix activate scripts
-    script_paths = [
-        venv_path / "bin" / "activate",
-        venv_path / "bin" / "activate.csh",
-        venv_path / "bin" / "activate.fish",
-        venv_path / "Scripts" / "activate.bat",
-        venv_path / "Scripts" / "Activate.ps1",
-    ]
-    for script in script_paths:
-        if script.exists():
+    # Fix all scripts in bin/Scripts (activation scripts, pip, wrappers, etc.)
+    for scripts_dir in [venv_path / "bin", venv_path / "Scripts"]:
+        if not scripts_dir.exists():
+            continue
+
+        for script in scripts_dir.iterdir():
+            if not script.is_file():
+                continue
+
             try:
-                t = script.read_text()
-                script.write_text(t.replace(old_str, new_str))
+                # Try to process as text first (for shell scripts, .bat, .ps1, python scripts)
+                try:
+                    t = script.read_text(encoding="utf-8")
+                    if old_str in t:
+                        script.write_text(t.replace(old_str, new_str), encoding="utf-8")
+                except UnicodeDecodeError:
+                    # Fallback for binary wrappers (e.g. pip.exe launcher)
+                    b = script.read_bytes()
+                    old_bytes = old_str.encode("utf-8")
+                    new_bytes = new_str.encode("utf-8")
+                    if old_bytes in b:
+                        script.write_bytes(b.replace(old_bytes, new_bytes))
             except OSError:
                 pass
 

--- a/src/pyvm_updater/venv.py
+++ b/src/pyvm_updater/venv.py
@@ -299,6 +299,100 @@ def remove_venv(name: str, force: bool = False) -> tuple[bool, str]:
         return False, f"Failed to remove venv: {e}"
 
 
+def _fix_venv_paths(venv_path: Path, old_path: Path) -> None:
+    """Fix hardcoded paths inside a copied venv so it points to its new location.
+
+    Args:
+        venv_path: The new venv directory.
+        old_path: The original venv directory that was copied.
+    """
+    old_str = str(old_path)
+    new_str = str(venv_path)
+
+    # Fix pyvenv.cfg
+    cfg = venv_path / "pyvenv.cfg"
+    if cfg.exists():
+        try:
+            t = cfg.read_text()
+            cfg.write_text(t.replace(old_str, new_str))
+        except OSError:
+            pass
+
+    # Fix activate scripts
+    script_paths = [
+        venv_path / "bin" / "activate",
+        venv_path / "bin" / "activate.csh",
+        venv_path / "bin" / "activate.fish",
+        venv_path / "Scripts" / "activate.bat",
+        venv_path / "Scripts" / "Activate.ps1",
+    ]
+    for script in script_paths:
+        if script.exists():
+            try:
+                t = script.read_text()
+                script.write_text(t.replace(old_str, new_str))
+            except OSError:
+                pass
+
+
+def duplicate_venv(source_name: str, new_name: str) -> tuple[bool, str]:
+    """Duplicate a virtual environment by copying it to a new name.
+
+    Copies the venv folder on disk, fixes internal paths, and registers
+    the new venv in the JSON registry.
+
+    Args:
+        source_name: Name of the existing venv to copy.
+        new_name: Name for the new copy.
+
+    Returns:
+        Tuple of (success, message).
+    """
+    registry = get_venv_registry()
+
+    # Resolve source path
+    if source_name in registry:
+        source_path = Path(registry[source_name].get("path", ""))
+    else:
+        source_path = get_venv_dir() / source_name
+
+    # Validate source exists on disk
+    if not source_path.exists():
+        return False, f"Venv '{source_name}' not found on disk"
+
+    # Validate new name is not taken
+    new_path = get_venv_dir() / new_name
+    if new_name in registry:
+        return False, f"Venv '{new_name}' already exists in registry"
+    if new_path.exists():
+        return False, f"Directory '{new_path}' already exists"
+
+    try:
+        # Copy the entire venv directory
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(str(source_path), str(new_path))
+
+        # Fix hardcoded paths in the copy
+        _fix_venv_paths(new_path, source_path)
+
+        # Register the new venv
+        if source_name in registry:
+            entry = dict(registry[source_name])
+        else:
+            entry = {"python_version": "unknown"}
+        entry["path"] = str(new_path)
+        registry[new_name] = entry
+        save_venv_registry(registry)
+
+        return True, f"Duplicated venv '{source_name}' as '{new_name}'"
+
+    except OSError as e:
+        # Clean up partial copy if it exists
+        if new_path.exists():
+            shutil.rmtree(new_path, ignore_errors=True)
+        return False, f"Failed to duplicate venv: {e}"
+
+
 def get_venv_activate_command(name: str) -> str | None:
     """Get the command to activate a venv.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,13 @@
 import pytest
 from click.testing import CliRunner
+
 from pyvm_updater.cli import cli
+
 
 @pytest.fixture
 def runner():
     return CliRunner()
+
 
 def test_install_dry_run(runner):
     """Verify that the install dry-run flag prints the correct message and exits 0."""
@@ -12,6 +15,7 @@ def test_install_dry_run(runner):
     assert result.exit_code == 0
     assert "[DRY-RUN]" in result.output
     assert "Would download and install Python 3.12.1" in result.output
+
 
 def test_remove_dry_run(runner):
     """Verify that the remove dry-run flag prints the correct message and exits 0."""

--- a/tests/test_venv_duplicate.py
+++ b/tests/test_venv_duplicate.py
@@ -152,6 +152,41 @@ class TestDuplicateVenv:
         assert str(venvs / "clone") in text
         assert str(venvs / "original") not in text
 
+    def test_duplicate_fixes_script_wrappers(self, venv_dir):
+        """Scripts like pip should have their shebang/path updated."""
+        venvs, registry_file = venv_dir
+        source_path = _make_fake_venv(venvs, "original")
+
+        # Make a fake pip script
+        bin_dir = source_path / "bin"
+        pip_script = bin_dir / "pip"
+        pip_script.write_text(f"#!{source_path}/bin/python\nprint('pip')")
+
+        # Make a fake binary executable (like pip.exe)
+        pip_exe = bin_dir / "pip.exe"
+        old_bytes = str(source_path).encode("utf-8")
+        pip_exe.write_bytes(b"PK\x03\x04" + old_bytes + b"\x00\x01")
+
+        registry = {
+            "original": {"path": str(source_path), "python_version": "3.13"},
+        }
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        p1, p2 = _apply_patches(patches)
+        with p1, p2:
+            success, msg = duplicate_venv("original", "clone")
+
+        assert success is True
+
+        new_pip = venvs / "clone" / "bin" / "pip"
+        assert str(venvs / "clone") in new_pip.read_text()
+        assert str(venvs / "original") not in new_pip.read_text()
+
+        new_pip_exe = venvs / "clone" / "bin" / "pip.exe"
+        assert str(venvs / "clone").encode("utf-8") in new_pip_exe.read_bytes()
+        assert str(venvs / "original").encode("utf-8") not in new_pip_exe.read_bytes()
+
     def test_duplicate_unregistered_venv(self, venv_dir):
         """Venv on disk but not in registry should still be duplicated."""
         venvs, registry_file = venv_dir

--- a/tests/test_venv_duplicate.py
+++ b/tests/test_venv_duplicate.py
@@ -1,0 +1,219 @@
+"""Tests for pyvm venv duplicate command."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pyvm_updater.venv import duplicate_venv, _fix_venv_paths
+
+
+@pytest.fixture
+def venv_dir(tmp_path):
+    """Create a temporary venv directory and registry."""
+    venvs = tmp_path / "venvs"
+    venvs.mkdir()
+    registry_file = tmp_path / "venvs.json"
+    return venvs, registry_file
+
+
+def _make_fake_venv(venv_dir, name):
+    """Create a fake venv directory with activate scripts and pyvenv.cfg."""
+    venv_path = venv_dir / name
+    bin_dir = venv_path / "bin"
+    bin_dir.mkdir(parents=True)
+
+    # Create activate script with hardcoded path
+    activate = bin_dir / "activate"
+    activate.write_text(f'VIRTUAL_ENV="{venv_path}"\nexport VIRTUAL_ENV\n')
+
+    # Create pyvenv.cfg
+    cfg = venv_path / "pyvenv.cfg"
+    cfg.write_text(f"home = /usr/bin\ninclude-system-site-packages = false\n")
+
+    return venv_path
+
+
+def _patch_venv(venv_dir, registry_file):
+    """Return context managers for patching venv module globals."""
+    return {
+        "pyvm_updater.venv.get_venv_dir": lambda: venv_dir,
+        "pyvm_updater.venv.VENV_REGISTRY": registry_file,
+    }
+
+
+def _apply_patches(patches):
+    """Helper to create nested patch context managers."""
+    keys = list(patches.keys())
+    return patch(keys[0], patches[keys[0]]), patch(keys[1], patches[keys[1]])
+
+
+class TestDuplicateVenv:
+
+    def test_duplicate_registered_venv(self, venv_dir):
+        venvs, registry_file = venv_dir
+        source_path = _make_fake_venv(venvs, "base-env")
+
+        registry = {
+            "base-env": {
+                "path": str(source_path),
+                "python_version": "3.13",
+                "python_executable": "/usr/bin/python",
+                "system_site_packages": False,
+            }
+        }
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        p1, p2 = _apply_patches(patches)
+        with p1, p2:
+            success, msg = duplicate_venv("base-env", "experimental-env")
+
+        assert success is True
+        assert "Duplicated" in msg
+
+        # Both exist on disk
+        assert source_path.exists()
+        assert (venvs / "experimental-env").exists()
+        assert (venvs / "experimental-env" / "bin" / "activate").exists()
+
+        # Registry has both
+        reg = json.loads(registry_file.read_text())
+        assert "base-env" in reg
+        assert "experimental-env" in reg
+        assert reg["experimental-env"]["python_version"] == "3.13"
+        assert "experimental-env" in reg["experimental-env"]["path"]
+
+    def test_duplicate_source_not_found(self, venv_dir):
+        venvs, registry_file = venv_dir
+        registry_file.write_text("{}")
+
+        patches = _patch_venv(venvs, registry_file)
+        p1, p2 = _apply_patches(patches)
+        with p1, p2:
+            success, msg = duplicate_venv("ghost", "new-name")
+
+        assert success is False
+        assert "not found" in msg
+
+    def test_duplicate_new_name_in_registry(self, venv_dir):
+        venvs, registry_file = venv_dir
+        _make_fake_venv(venvs, "aaa")
+
+        registry = {
+            "aaa": {"path": str(venvs / "aaa"), "python_version": "3.12"},
+            "bbb": {"path": str(venvs / "bbb"), "python_version": "3.12"},
+        }
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        p1, p2 = _apply_patches(patches)
+        with p1, p2:
+            success, msg = duplicate_venv("aaa", "bbb")
+
+        assert success is False
+        assert "already exists" in msg
+
+    def test_duplicate_new_dir_exists(self, venv_dir):
+        venvs, registry_file = venv_dir
+        _make_fake_venv(venvs, "aaa")
+        _make_fake_venv(venvs, "bbb")
+
+        registry = {"aaa": {"path": str(venvs / "aaa"), "python_version": "3.12"}}
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        p1, p2 = _apply_patches(patches)
+        with p1, p2:
+            success, msg = duplicate_venv("aaa", "bbb")
+
+        assert success is False
+        assert "already exists" in msg
+
+    def test_duplicate_fixes_activate_paths(self, venv_dir):
+        """Activate script in the copy should reference the new path."""
+        venvs, registry_file = venv_dir
+        source_path = _make_fake_venv(venvs, "original")
+
+        registry = {
+            "original": {"path": str(source_path), "python_version": "3.13"},
+        }
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        p1, p2 = _apply_patches(patches)
+        with p1, p2:
+            success, msg = duplicate_venv("original", "clone")
+
+        assert success is True
+
+        new_activate = venvs / "clone" / "bin" / "activate"
+        text = new_activate.read_text()
+        assert str(venvs / "clone") in text
+        assert str(venvs / "original") not in text
+
+    def test_duplicate_unregistered_venv(self, venv_dir):
+        """Venv on disk but not in registry should still be duplicated."""
+        venvs, registry_file = venv_dir
+        _make_fake_venv(venvs, "orphan")
+        registry_file.write_text("{}")
+
+        patches = _patch_venv(venvs, registry_file)
+        p1, p2 = _apply_patches(patches)
+        with p1, p2:
+            success, msg = duplicate_venv("orphan", "adopted")
+
+        assert success is True
+        assert (venvs / "adopted").exists()
+
+        reg = json.loads(registry_file.read_text())
+        assert "adopted" in reg
+
+    def test_duplicate_preserves_source(self, venv_dir):
+        """Source venv should remain untouched after duplication."""
+        venvs, registry_file = venv_dir
+        source_path = _make_fake_venv(venvs, "keep-me")
+
+        registry = {
+            "keep-me": {"path": str(source_path), "python_version": "3.13"},
+        }
+        registry_file.write_text(json.dumps(registry))
+
+        patches = _patch_venv(venvs, registry_file)
+        p1, p2 = _apply_patches(patches)
+        with p1, p2:
+            duplicate_venv("keep-me", "copy")
+
+        # Source still intact
+        assert source_path.exists()
+        activate_text = (source_path / "bin" / "activate").read_text()
+        assert str(source_path) in activate_text
+
+
+class TestFixVenvPaths:
+
+    def test_replaces_old_path_in_activate(self, tmp_path):
+        old_path = tmp_path / "old-env"
+        new_path = tmp_path / "new-env"
+        new_path.mkdir()
+        bin_dir = new_path / "bin"
+        bin_dir.mkdir()
+
+        activate = bin_dir / "activate"
+        activate.write_text(f'VIRTUAL_ENV="{old_path}"\n')
+
+        _fix_venv_paths(new_path, old_path)
+
+        text = activate.read_text()
+        assert str(new_path) in text
+        assert str(old_path) not in text
+
+    def test_handles_missing_scripts(self, tmp_path):
+        """Should not crash if some activate scripts don't exist."""
+        old_path = tmp_path / "old"
+        new_path = tmp_path / "new"
+        new_path.mkdir()
+
+        # Should not raise
+        _fix_venv_paths(new_path, old_path)

--- a/tests/test_venv_duplicate.py
+++ b/tests/test_venv_duplicate.py
@@ -1,12 +1,11 @@
 """Tests for pyvm venv duplicate command."""
 
 import json
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from pyvm_updater.venv import duplicate_venv, _fix_venv_paths
+from pyvm_updater.venv import _fix_venv_paths, duplicate_venv
 
 
 @pytest.fixture
@@ -30,7 +29,7 @@ def _make_fake_venv(venv_dir, name):
 
     # Create pyvenv.cfg
     cfg = venv_path / "pyvenv.cfg"
-    cfg.write_text(f"home = /usr/bin\ninclude-system-site-packages = false\n")
+    cfg.write_text("home = /usr/bin\ninclude-system-site-packages = false\n")
 
     return venv_path
 


### PR DESCRIPTION
Adds `pyvm venv duplicate <source> <new>` to clone an existing virtual environment.

Copies the venv folder on disk, patches hardcoded paths in activate scripts and `pyvenv.cfg`, and registers the clone in the JSON registry. Cleans up partial copies on failure.

- Handles registered and unregistered source venvs
- Validates source exists and new name is not taken
- Preserves original venv untouched
- 9 tests covering all scenarios

Closes #85

GSSoC26

<img width="1461" height="649" alt="image" src="https://github.com/user-attachments/assets/339cee6a-a1e6-4e55-97da-10234f4e2492" />
