### PR TITLE
fix: add missing T keybinding to toggle TUI theme

### DIFF
--- a/src/pyvm_updater/tui.py
+++ b/src/pyvm_updater/tui.py
@@ -803,17 +803,25 @@ class MainScreen(Screen):
 
     def action_toggle_theme(self) -> None:
         """Cycle through all available TUI themes."""
-        themes = sorted(self.app.available_themes.keys())
-        current = self.app.theme
-        try:
-            idx = themes.index(current)
-            next_theme = themes[(idx + 1) % len(themes)]
-        except ValueError:
-            next_theme = themes[0]
-        self.app.theme = next_theme
         cfg = get_config()
+        next_theme = "dark"
+
+        if hasattr(self.app, "available_themes") and hasattr(self.app, "theme"):
+            themes = sorted(self.app.available_themes.keys())
+            current = self.app.theme
+            try:
+                idx = themes.index(current)
+                next_theme = themes[(idx + 1) % len(themes)]
+            except ValueError:
+                next_theme = themes[0] if themes else "textual-dark"
+            self.app.theme = next_theme
+        elif hasattr(self.app, "dark"):
+            self.app.dark = not self.app.dark
+            next_theme = "dark" if self.app.dark else "light"
+
         cfg.set("tui", "theme", next_theme)
         cfg.save()
+
         status_bar = self.query_one("#status-bar", StatusBar)
         status_bar.set_message(f"Theme: {next_theme}", "green")
 
@@ -994,13 +1002,23 @@ class PyvmTUI(App):
         # Apply saved theme preference from config
         cfg = get_config()
         saved = cfg.tui_theme
-        # Support legacy "dark"/"light" values from older configs
-        if saved == "dark":
-            saved = "textual-dark"
-        elif saved == "light":
-            saved = "textual-light"
-        if saved in self.available_themes:
-            self.theme = saved
+
+        # Support new API
+        if hasattr(self, "available_themes") and hasattr(self, "theme"):
+            # Support legacy "dark"/"light" values from older configs
+            if saved == "dark":
+                saved = "textual-dark"
+            elif saved == "light":
+                saved = "textual-light"
+            if saved in self.available_themes:
+                self.theme = saved
+        # Support old API
+        elif hasattr(self, "dark"):
+            if saved in ("light", "textual-light"):
+                self.dark = False
+            elif saved in ("dark", "textual-dark"):
+                self.dark = True
+
         self.push_screen("main")
 
 

--- a/src/pyvm_updater/tui.py
+++ b/src/pyvm_updater/tui.py
@@ -952,7 +952,7 @@ class HelpScreen(Screen):
   R         Refresh data
   U         Update to latest version
   W         Install wizard
-  T         Toggle theme (dark/light)
+  T         Toggle theme
   B         Rollback last action
   ?         This help
   Q         Quit

--- a/src/pyvm_updater/tui.py
+++ b/src/pyvm_updater/tui.py
@@ -1012,3 +1012,4 @@ def run_tui():
 
 if __name__ == "__main__":
     run_tui()
+

--- a/src/pyvm_updater/tui.py
+++ b/src/pyvm_updater/tui.py
@@ -22,6 +22,7 @@ except ImportError:
     sys.exit(1)
 
 # Import from new modular structure
+from .config import get_config
 from .constants import HISTORY_FILE
 from .history import HistoryManager
 from .installers import (
@@ -32,7 +33,6 @@ from .installers import (
     update_python_macos,
     update_python_windows,
 )
-from .config import get_config
 from .utils import get_os_info
 from .version import check_python_version, get_active_python_releases, get_installed_python_versions
 from .wizard import WizardScreen

--- a/src/pyvm_updater/tui.py
+++ b/src/pyvm_updater/tui.py
@@ -1012,4 +1012,3 @@ def run_tui():
 
 if __name__ == "__main__":
     run_tui()
-

--- a/src/pyvm_updater/tui.py
+++ b/src/pyvm_updater/tui.py
@@ -32,6 +32,7 @@ from .installers import (
     update_python_macos,
     update_python_windows,
 )
+from .config import get_config
 from .utils import get_os_info
 from .version import check_python_version, get_active_python_releases, get_installed_python_versions
 from .wizard import WizardScreen
@@ -153,6 +154,7 @@ class MainScreen(Screen):
         Binding("u", "update_latest", "Update"),
         Binding("b", "rollback", "Rollback"),
         Binding("w", "start_wizard", "Wizard"),
+        Binding("t", "toggle_theme", "Theme"),
         Binding("1", "focus_installed", "Installed", show=False),
         Binding("2", "focus_available", "Available", show=False),
         Binding("?", "help", "Help"),
@@ -300,7 +302,7 @@ class MainScreen(Screen):
 
             yield Static(
                 "[dim]Tab: switch panels | Arrow keys: navigate | Enter: install | X: remove | "
-                "R: refresh | U: update | B: rollback | Q: quit[/dim]",
+                "R: refresh | U: update | B: rollback | T: theme | Q: quit[/dim]",
                 id="hint-bar",
             )
 
@@ -799,6 +801,22 @@ class MainScreen(Screen):
 
         self.refresh_all()
 
+    def action_toggle_theme(self) -> None:
+        """Cycle through all available TUI themes."""
+        themes = sorted(self.app.available_themes.keys())
+        current = self.app.theme
+        try:
+            idx = themes.index(current)
+            next_theme = themes[(idx + 1) % len(themes)]
+        except ValueError:
+            next_theme = themes[0]
+        self.app.theme = next_theme
+        cfg = get_config()
+        cfg.set("tui", "theme", next_theme)
+        cfg.save()
+        status_bar = self.query_one("#status-bar", StatusBar)
+        status_bar.set_message(f"Theme: {next_theme}", "green")
+
     def action_quit(self) -> None:
         self.app.exit()
 
@@ -934,6 +952,7 @@ class HelpScreen(Screen):
   R         Refresh data
   U         Update to latest version
   W         Install wizard
+  T         Toggle theme (dark/light)
   B         Rollback last action
   ?         This help
   Q         Quit
@@ -972,6 +991,16 @@ class PyvmTUI(App):
     }
 
     def on_mount(self) -> None:
+        # Apply saved theme preference from config
+        cfg = get_config()
+        saved = cfg.tui_theme
+        # Support legacy "dark"/"light" values from older configs
+        if saved == "dark":
+            saved = "textual-dark"
+        elif saved == "light":
+            saved = "textual-light"
+        if saved in self.available_themes:
+            self.theme = saved
         self.push_screen("main")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,13 @@
 import pytest
 from click.testing import CliRunner
+
 from pyvm_updater.cli import cli
+
 
 @pytest.fixture
 def runner():
     return CliRunner()
+
 
 def test_install_dry_run(runner):
     """Verify that the install dry-run flag prints the correct message and exits 0."""
@@ -12,6 +15,7 @@ def test_install_dry_run(runner):
     assert result.exit_code == 0
     assert "[DRY-RUN]" in result.output
     assert "Would download and install Python 3.12.1" in result.output
+
 
 def test_remove_dry_run(runner):
     """Verify that the remove dry-run flag prints the correct message and exits 0."""


### PR DESCRIPTION
### Summary
This PR implements the missing 'T' keybinding in the TUI, as specified in the README, and enhances theme support.

### Changes
- **Cycle Themes**: Pressing `T` now cycles through all 20+ available Textual themes (Dracula, Nord, Monokai, etc.) rather than just toggling dark/light.
- **Persistence**: The selected theme is now saved to `config.toml` and automatically restored on the next startup.
- **API Fix**: Updated the implementation to use the correct `app.theme` API (fixing compatibility issues with Textual 8.x where `app.dark` was deprecated).
- **UI Updates**: Added `T: theme` to the main hint bar and updated the Help screen (`?`) to include the new shortcut.

<img width="1920" height="970" alt="20260514-2200-10 1356304" src="https://github.com/user-attachments/assets/e8f3314e-db35-4503-82dc-3f9913e4fd6b" />


### Related Issue
Closes #79

GSSoC26