### PR TITLE
fix: use startswith for prerelease check to avoid false positives (closes #101)

### DIFF
--- a/src/pyvm_updater/version.py
+++ b/src/pyvm_updater/version.py
@@ -422,7 +422,7 @@ def is_python_version_installed(version_str: str) -> bool:
 
 def _normalize_status(text: str) -> str:
     t = text.lower()
-    if "pre-release" in t or "pre" in t:
+    if "pre-release" in t or t.startswith("pre"):
         return "prerelease"
     if "bugfix" in t or "active" in t:
         return "active"

--- a/src/pyvm_updater/version.py
+++ b/src/pyvm_updater/version.py
@@ -422,7 +422,7 @@ def is_python_version_installed(version_str: str) -> bool:
 
 def _normalize_status(text: str) -> str:
     t = text.lower()
-    if "pre-release" in t or t.startswith("pre"):
+    if t in ("pre-release", "pre", "prerelease"):
         return "prerelease"
     if "bugfix" in t or "active" in t:
         return "active"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -94,24 +94,29 @@ class TestNormalizeStatus:
     def test_prerelease_hyphenated(self):
         """Test that 'pre-release' is classified as prerelease."""
         from pyvm_updater.version import _normalize_status
+
         assert _normalize_status("pre-release") == "prerelease"
 
     def test_prerelease_exact(self):
         """Test that 'prerelease' is classified as prerelease."""
         from pyvm_updater.version import _normalize_status
+
         assert _normalize_status("prerelease") == "prerelease"
 
     def test_pre_exact(self):
         """Test that 'pre' is classified as prerelease."""
         from pyvm_updater.version import _normalize_status
+
         assert _normalize_status("pre") == "prerelease"
 
     def test_deprecated_no_false_positive(self):
         """Test that 'deprecated' is NOT classified as prerelease."""
         from pyvm_updater.version import _normalize_status
+
         assert _normalize_status("deprecated") != "prerelease"
 
     def test_prepared_no_false_positive(self):
         """Test that 'prepared' is NOT classified as prerelease."""
         from pyvm_updater.version import _normalize_status
+
         assert _normalize_status("prepared") != "prerelease"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -84,3 +84,34 @@ class TestIsPythonVersionInstalled:
 
         # The current full version should definitely be installed
         assert is_python_version_installed(current_ver) is True
+
+
+class TestNormalizeStatus:
+    """Tests for _normalize_status function."""
+
+    from pyvm_updater.version import _normalize_status
+
+    def test_prerelease_hyphenated(self):
+        """Test that 'pre-release' is classified as prerelease."""
+        from pyvm_updater.version import _normalize_status
+        assert _normalize_status("pre-release") == "prerelease"
+
+    def test_prerelease_exact(self):
+        """Test that 'prerelease' is classified as prerelease."""
+        from pyvm_updater.version import _normalize_status
+        assert _normalize_status("prerelease") == "prerelease"
+
+    def test_pre_exact(self):
+        """Test that 'pre' is classified as prerelease."""
+        from pyvm_updater.version import _normalize_status
+        assert _normalize_status("pre") == "prerelease"
+
+    def test_deprecated_no_false_positive(self):
+        """Test that 'deprecated' is NOT classified as prerelease."""
+        from pyvm_updater.version import _normalize_status
+        assert _normalize_status("deprecated") != "prerelease"
+
+    def test_prepared_no_false_positive(self):
+        """Test that 'prepared' is NOT classified as prerelease."""
+        from pyvm_updater.version import _normalize_status
+        assert _normalize_status("prepared") != "prerelease"


### PR DESCRIPTION
##  Problem
`_normalize_status` in `src/pyvm_updater/version.py` used 
a substring match `"pre" in t` which incorrectly classifies 
unrelated statuses as prerelease.

Example:
_normalize_status("deprecated")  # returned "prerelease" ❌
_normalize_status("prepared")    # returned "prerelease" ❌

##  Fix
Changed `"pre" in t` to `t.startswith("pre")` so only 
statuses that actually begin with "pre" are classified 
as prerelease.

##  Testing
_normalize_status("deprecated")  # now returns "deprecated" ✅
_normalize_status("pre-release")  # still returns "prerelease" ✅
_normalize_status("pre")          # still returns "prerelease" ✅

##  File Changed
- `src/pyvm_updater/version.py` — `_normalize_status` function

Closes #101