### PR TITLE
Add `pyvm venv path` command

### DIFF
--- a/src/pyvm_updater/cli.py
+++ b/src/pyvm_updater/cli.py
@@ -845,7 +845,7 @@ def venv_path(name: str) -> None:
     else:
         click.echo(f"[X] Venv '{name}' not found.")
         sys.exit(1)
-        
+
 
 @venv.command("rename")
 @click.argument("old_name")

--- a/src/pyvm_updater/cli.py
+++ b/src/pyvm_updater/cli.py
@@ -832,6 +832,21 @@ def venv_activate(name: str) -> None:
         sys.exit(1)
 
 
+@venv.command("path")
+@click.argument("name")
+def venv_path(name: str) -> None:
+    """Show the absolute path of a virtual environment."""
+    from .venv import get_venv_path
+
+    path = get_venv_path(name)
+
+    if path:
+        click.echo(path)
+    else:
+        click.echo(f"[X] Venv '{name}' not found.")
+        sys.exit(1)
+        
+
 @venv.command("rename")
 @click.argument("old_name")
 @click.argument("new_name")

--- a/src/pyvm_updater/venv.py
+++ b/src/pyvm_updater/venv.py
@@ -498,3 +498,25 @@ def get_venv_activate_command(name: str) -> str | None:
             return f"source {activate_script}"
 
     return None
+
+
+def get_venv_path(name: str) -> str | None:
+    """Get the path of a virtual environment.
+
+    Args:
+        name: Name of the venv.
+
+    Returns:
+        Path string, or None if venv not found.
+    """
+    registry = get_venv_registry()
+
+    if name in registry:
+        venv_path = Path(registry[name].get("path", ""))
+    else:
+        venv_path = get_venv_dir() / name
+
+    if not venv_path.exists():
+        return None
+
+    return str(venv_path)


### PR DESCRIPTION
## Summary

Added a new `pyvm venv path <name>`command to display the path of a virtual environment.

The command uses the existing `venv` and shows an error message if the venv does not exist.
