### PR TITLE
fix: use HistoryManager.pop_last_action() in rollback instead of raw file I/O

### DIFF
--- a/src/pyvm_updater/cli.py
+++ b/src/pyvm_updater/cli.py
@@ -17,7 +17,6 @@ from rich.console import Console
 
 from . import __version__
 from .config import get_config
-from .constants import HISTORY_FILE
 from .history import HistoryManager
 from .installers import (
     remove_python_linux,
@@ -105,14 +104,7 @@ def rollback(yes: bool) -> None:
 
         if success:
             click.echo(f"\nSuccessfully rolled back: Python {version} removed.")
-            history = HistoryManager.get_history()
-            if history:
-                history.pop()
-                try:
-                    with open(HISTORY_FILE, "w") as f:
-                        json.dump(history, f, indent=2)
-                except Exception:
-                    pass
+            HistoryManager.pop_last_action()
         else:
             click.echo("\nRollback encountered issues.")
             sys.exit(1)

--- a/src/pyvm_updater/history.py
+++ b/src/pyvm_updater/history.py
@@ -53,3 +53,18 @@ class HistoryManager:
         if not history:
             return None
         return history[-1]
+
+    @staticmethod
+    def pop_last_action() -> dict[Any, Any] | None:
+        """Remove and return the last history entry, persisting the change."""
+        history = HistoryManager.get_history()
+        if not history:
+            return None
+        entry = history.pop()
+        try:
+            HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+            with open(HISTORY_FILE, "w") as f:
+                json.dump(history, f, indent=2)
+        except Exception as e:
+            print(f"Warning: Could not update history: {e}")
+        return entry

--- a/src/pyvm_updater/tui.py
+++ b/src/pyvm_updater/tui.py
@@ -23,7 +23,6 @@ except ImportError:
 
 # Import from new modular structure
 from .config import get_config
-from .constants import HISTORY_FILE
 from .history import HistoryManager
 from .installers import (
     remove_python_linux,
@@ -736,7 +735,6 @@ class MainScreen(Screen):
 
     def run_rollback_with_suspend(self, version: str) -> None:
         """Run rollback with TUI suspended"""
-        import json
 
         from textual.app import SuspendNotSupported
 
@@ -775,15 +773,7 @@ class MainScreen(Screen):
                         success = do_rollback()
                         if success:
                             print("\nRollback complete!")
-                            # Update history file
-                            history = HistoryManager.get_history()
-                            if history:
-                                history.pop()
-                                try:
-                                    with open(HISTORY_FILE, "w") as f:
-                                        json.dump(history, f, indent=2)
-                                except Exception:
-                                    pass
+                            HistoryManager.pop_last_action()
                         else:
                             print("\nRollback failed.")
                     else:


### PR DESCRIPTION
cli.py and tui.py were doing manual json.dump(history) after popping the last entry — duplicating what HistoryManager already handles, and silently swallowing write errors.

moved the pop+persist logic into a new pop_last_action() method on HistoryManager and updated both callers. also removed now-unused HISTORY_FILE and json imports.

Fixes #119

GSSOC 2026 contribution