### PR TITLE
docs: fix misleading 'runtime only' docstring on Config.set()

### DIFF
--- a/src/pyvm_updater/config.py
+++ b/src/pyvm_updater/config.py
@@ -93,7 +93,7 @@ class Config:
             return default
 
     def set(self, section: str, key: str, value: Any) -> None:
-        """Set a configuration value (runtime only, not persisted).
+        """Set a configuration value. Call save() to persist to disk.
 
         Args:
             section: Config section.


### PR DESCRIPTION
the docstring said 'runtime only, not persisted' but the CLI's config --set command calls save() right after set(), which does write to disk. updated to clarify that save() must be called to persist.

Fixes #121

GSSOC 2026 contribution