### PR TITLE
fix: add bandit and pip-audit to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ dev = [
     "mypy>=0.900",
     "textual-dev>=1.0.0",
     "ruff>=0.0.280",
+    "bandit[toml]>=1.7",
+    "pip-audit>=0.0.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
both tools are used in CI (pr-review.yml) and mentioned in CONTRIBUTING.md, but weren't listed in the dev extras. anyone running `pip install -e ".[dev]"` would miss them.

Fixes #123

GSSOC 2026 contribution