### PR TITLE
refactor: use context manager for _sync_lock instead of acquire/release

### DIFF
--- a/src/pyvm_updater/metadata_store.py
+++ b/src/pyvm_updater/metadata_store.py
@@ -180,14 +180,8 @@ def start_background_sync_if_stale() -> None:
         return
 
     def _run():
-        try:
-            _sync_lock.acquire()
+        with _sync_lock:
             sync_python_org()
-        finally:
-            try:
-                _sync_lock.release()
-            except Exception:
-                pass
 
     t = threading.Thread(target=_run, daemon=True)
     t.start()


### PR DESCRIPTION
the nested try/except to swallow release errors was a smell. a threading lock's release() shouldn't fail unless it was never acquired, which the with statement prevents.

Fixes #125

GSSOC 2026 contribution