### PR TITLE
fix: remove stale manual dep install from install scripts

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -24,24 +24,10 @@ if %errorlevel% neq 0 (
     set PIP_CMD=pip
 )
 
-echo Installing required packages...
+echo Installing pyvm and dependencies...
 echo.
 
-REM Install the package
-%PIP_CMD% install requests beautifulsoup4 packaging click
-
-if %errorlevel% neq 0 (
-    echo.
-    echo Failed to install dependencies.
-    pause
-    exit /b 1
-)
-
-echo.
-echo Installing pyvm from current directory...
-echo.
-
-REM Install in editable mode
+REM Install in editable mode (handles all deps from pyproject.toml)
 %PIP_CMD% install -e .
 
 if %errorlevel% equ 0 (

--- a/install.sh
+++ b/install.sh
@@ -24,23 +24,10 @@ else
     PIP_CMD="pip"
 fi
 
-echo "📦 Installing required packages..."
+echo "📦 Installing pyvm and dependencies..."
 echo ""
 
-# Install the package
-$PIP_CMD install requests beautifulsoup4 packaging click
-
-if [ $? -ne 0 ]; then
-    echo ""
-    echo "❌ Failed to install dependencies."
-    exit 1
-fi
-
-echo ""
-echo "📥 Installing pyvm from current directory..."
-echo ""
-
-# Install in editable mode
+# Install in editable mode (handles all deps from pyproject.toml)
 $PIP_CMD install -e .
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
install.sh and install.bat manually listed 4 of 6 runtime dependencies (missing textual and rich), then ran pip install -e . which installs the full set anyway. the manual step was redundant and already stale.

Fixes #127

GSSOC 2026 contribution