### PR TITLE
fix: remove trailing whitespace in pyproject.toml deps list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,7 @@ dependencies = [
     "packaging>=20.0",
     "click>=8.0.0",
     "textual>=0.40.0",
-    "rich>=13.0.0",     # Used for enhanced CLI progress bars
-   
+    "rich>=13.0.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
line 25 had trailing spaces after the comment, line 26 was blank before the closing bracket.

Fixes #128

GSSOC 2026 contribution