### PR TITLE
Improve helper tool warning message for windows users

### DIFF
--- a/src/pyvm_updater/cli.py
+++ b/src/pyvm_updater/cli.py
@@ -890,7 +890,7 @@ def doctor():
         tool = "pyenv" if pyenv_path else "mise"
         click.secho(f" [✓] Helper Tool: Found {tool} at {pyenv_path or mise_path}", fg="green")
     else:
-        click.secho(" [!] Helper Tool: Neither pyenv nor mise found. (Recommended for Linux/macOS)", fg="yellow")
+        click.secho(" [!] Helper Tool: Neither pyenv nor mise found. These tools are mainly recommended for Linux/macOS(optional for windows).", fg="yellow")
 
     # 2. Check Network Reachability
     try:


### PR DESCRIPTION
Improved the helper tool warning message shown during  pyvm doctor  checks.

The previous wording could be confusing for Windows users because pyenv  and  mise  are primarily recommended for Linux/macOS environments. Updated the message to clarify that these tools are optional on Windows systems.
