### PR TITLE
Block --build-from-source  usage on windows

### DIFF
--- a/src/pyvm_updater/cli.py
+++ b/src/pyvm_updater/cli.py
@@ -890,7 +890,7 @@ def doctor():
         tool = "pyenv" if pyenv_path else "mise"
         click.secho(f" [✓] Helper Tool: Found {tool} at {pyenv_path or mise_path}", fg="green")
     else:
-        click.secho(" [!] Helper Tool: Neither pyenv nor mise found. (Recommended for Linux/macOS)", fg="yellow")
+        click.secho(" [!] Helper Tool: Neither pyenv nor mise found. These tools are mainly recommended for Linux/macOS(optional for windows).", fg="yellow")
 
     # 2. Check Network Reachability
     try:

--- a/src/pyvm_updater/cli.py
+++ b/src/pyvm_updater/cli.py
@@ -188,10 +188,18 @@ def install(
         pyvm install 3.11.5 --yes
         pyvm install 3.12.1 --installer pyenv
     """
+    
+    
 
     if dry_run:
         click.secho(f"[DRY-RUN] Would download and install Python {version}", fg="yellow")
         return
+    if build_from_source and platform.system() == "Windows":
+          click.secho(
+                       "The --build-from-source option is only supported on Linux.",
+        fg="red"
+    )
+    raise click.Abort()
 
     try:
         if not validate_version_string(version) or len(version.split(".")) < 3:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,3 +23,13 @@ def test_remove_dry_run(runner):
     assert result.exit_code == 0
     assert "[DRY-RUN]" in result.output
     assert "Would remove Python 3.12.1" in result.output
+
+    
+def test_build_from_source_windows(runner):
+    result = runner.invoke(
+        cli,
+        ["install", "3.12.1", "--build-from-source"]
+    )
+
+    assert result.exit_code != 0
+    assert "only supported on Linux" in result.output


### PR DESCRIPTION
Fixes #132

Added platform validation for the `--build-from-source` option during installation.

Changes made:
- blocks unsupported usage on Windows,
- displays a clear error message,
- preserves dry-run functionality,
- adds test coverage for Windows behavior.