### PR TITLE
test: add tests for "pyvm doctor"

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from click.testing import CliRunner
 
@@ -23,3 +25,62 @@ def test_remove_dry_run(runner):
     assert result.exit_code == 0
     assert "[DRY-RUN]" in result.output
     assert "Would remove Python 3.12.1" in result.output
+
+
+def test_doctor_all_pass(runner):
+    """All three checks pass."""
+    with (
+        patch("pyvm_updater.cli.shutil.which") as mock_which,
+        patch("pyvm_updater.cli.requests.get"),
+        patch("pyvm_updater.cli.os.access") as mock_access,
+    ):
+        mock_which.side_effect = lambda x: "/usr/bin/" + x if x == "pyenv" else None
+        mock_access.return_value = True
+        result = runner.invoke(cli, ["doctor"])
+    assert result.exit_code == 0
+    assert "System is healthy" in result.output
+
+
+def test_doctor_missing_helper_tool(runner):
+    """pyenv and mise both absent — warning only, still healthy."""
+    with (
+        patch("pyvm_updater.cli.shutil.which", return_value=None),
+        patch("pyvm_updater.cli.requests.get"),
+        patch("pyvm_updater.cli.os.access") as mock_access,
+    ):
+        mock_access.return_value = True
+        result = runner.invoke(cli, ["doctor"])
+    assert result.exit_code == 0
+    assert "Neither pyenv nor mise found" in result.output
+    assert "System is healthy" in result.output
+
+
+def test_doctor_network_failure(runner):
+    """Network unreachable marks overall health as failed."""
+    with (
+        patch("pyvm_updater.cli.shutil.which") as mock_which,
+        patch("pyvm_updater.cli.requests.get") as mock_get,
+        patch("pyvm_updater.cli.os.access") as mock_access,
+    ):
+        mock_which.side_effect = lambda x: "/usr/bin/" + x if x == "pyenv" else None
+        mock_get.side_effect = Exception("Connection failed")
+        mock_access.return_value = True
+        result = runner.invoke(cli, ["doctor"])
+    assert result.exit_code == 0
+    assert "Failed to reach python.org" in result.output
+    assert "Some checks failed" in result.output
+
+
+def test_doctor_no_permission(runner):
+    """Home directory not writable marks overall health as failed."""
+    with (
+        patch("pyvm_updater.cli.shutil.which") as mock_which,
+        patch("pyvm_updater.cli.requests.get"),
+        patch("pyvm_updater.cli.os.access") as mock_access,
+    ):
+        mock_which.side_effect = lambda x: "/usr/bin/" + x if x == "pyenv" else None
+        mock_access.return_value = False
+        result = runner.invoke(cli, ["doctor"])
+    assert result.exit_code == 0
+    assert "No write access" in result.output
+    assert "Some checks failed" in result.output


### PR DESCRIPTION
## Summary
Add test coverage for `pyvm doctor` command.

Closes #112

## Changes
- `tests/test_cli.py` — added 4 test functions covering all `doctor()` code paths:
  - `test_doctor_all_pass` — all checks pass
  - `test_doctor_missing_helper_tool` — pyenv/mise absent (warning, not failure)
  - `test_doctor_network_failure` — python.org unreachable
  - `test_doctor_no_permission` — home directory not writable

## Testing
```
pytest tests/test_cli.py -v       # 6 passed (2 existing + 4 new)
ruff format --check tests/          # clean
ruff check tests/                   # clean
```
