### PR TITLE
feat: add pre-formatted issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name:  Bug Report
+about: Create a report to help us improve pyvm-updater
+title: 'fix: '
+labels: ['bug']
+assignees: ''
+---
+
+### Describe the Bug
+A clear and concise description of what the bug is.
+
+### Environment Details
+- **Operating System & Version:** 
+- **Python Version:** 
+- **pyvm Version:** 
+
+### Steps to Reproduce
+Steps to reproduce the behavior:
+1. Run command '...'
+2. See error
+
+### Expected Behavior
+A clear and concise description of what you expected to happen.
+
+### Actual Logs/Traceback
+```text
+Paste your terminal error logs or traceback details here

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name:  Feature Request
+about: Suggest an idea or new functionality for this project
+title: 'feat: '
+labels: ['enhancement']
+assignees: ''
+---
+
+### Problem Description
+Is your feature request related to a problem? Please describe it clearly.
+
+### Proposed Solution
+A clear and concise description of what you want to happen.
+
+### Alignment with Safety Guidelines
+Does this modification alter system Python defaults or require admin privileges for basic operations? (See CONTRIBUTING.md)
+
+### Additional Context
+Add any other context, mockups, or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+### Description
+Please include a summary of the changes and Fixes # (issue number)
+
+### Type of Change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Documentation update
+
+### Pre-Review Checklist
+Before requesting review, please confirm you completed these verification steps from `CONTRIBUTING.md`:
+- [ ] I have run the **Black** formatter locally (`black src/ tests/`)
+- [ ] I have verified code quality using **Ruff** / **Flake8**
+- [ ] I have executed local **tests** via `pytest tests/ -v` and they all pass
+- [ ] My commits follow the conventional commit standard (`fix:`, `feat:`, `docs:`)


### PR DESCRIPTION
fixes #197

i've added structured templates to help contributors write better issues and prs, matching what's requested in the contributing guidelines.

### what's changed:
* added `.github/ISSUE_TEMPLATE/bug_report.md` for bug tracking (os, python version, logs)
* added `.github/ISSUE_TEMPLATE/feature_request.md` for new ideas
* added `.github/pull_request_template.md` with a pre-review checklist

<img width="1919" height="744" alt="Screenshot 2026-05-31 021657" src="https://github.com/user-attachments/assets/05afeef5-9e66-44ed-a969-b889673f87f7" />


tested everything locally on my fork and it's working perfectly. @shreyasmene06 please review when you get a chance and add the appropriate gssoc labels