### PR TITLE
#202-Add SHA256 verification for Linux source installations

### DIFF
--- a/src/pyvm_updater/plugins/standard.py
+++ b/src/pyvm_updater/plugins/standard.py
@@ -530,6 +530,15 @@ class SourceInstaller(InstallerPlugin):
             print("❌ Failed to download source code.")
             return False
 
+        checksum_url = source_url + ".sha256"
+        if not verify_file_checksum(source_path, checksum_url):
+            print("Aborting installation due to integrity check failure")
+            try:
+                os.remove(source_path)
+            except OSError:
+                pass
+            return False
+
         build_dir = os.path.join(temp_dir, f"Python-{version}")
         try:
             print("📦 Extracting and Compiling (this will take a few minutes)...")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from pyvm_updater.plugins.base import InstallerPlugin
 from pyvm_updater.plugins.manager import PluginManager
-from pyvm_updater.plugins.standard import MiseInstaller
+from pyvm_updater.plugins.standard import MiseInstaller, SourceInstaller
 
 
 class TestPluginManager:
@@ -100,3 +100,55 @@ class CustomTestPlugin(InstallerPlugin):
             # Clean up (remove from registered plugins)
             if "custom-test" in pm._plugins:
                 del pm._plugins["custom-test"]
+
+
+class TestSourceInstaller:
+    """Tests for the source installer."""
+
+    def test_install_verifies_downloaded_source_before_extracting(self, tmp_path):
+        """Source installs should verify the tarball before extraction or compilation."""
+        installer = SourceInstaller()
+        version = "3.12.1"
+        source_path = tmp_path / f"Python-{version}.tar.xz"
+
+        def fake_download(_url, destination):
+            Path(destination).write_bytes(b"source archive")
+            return True
+
+        with (
+            patch.object(installer, "_install_dependencies", return_value=True),
+            patch("pyvm_updater.plugins.standard.tempfile.gettempdir", return_value=str(tmp_path)),
+            patch("pyvm_updater.plugins.standard.download_file", side_effect=fake_download),
+            patch("pyvm_updater.plugins.standard.verify_file_checksum", return_value=True) as verify_checksum,
+            patch("pyvm_updater.plugins.standard.subprocess.run") as run,
+        ):
+            assert installer.install(version) is True
+
+        verify_checksum.assert_called_once_with(
+            str(source_path),
+            f"https://www.python.org/ftp/python/{version}/Python-{version}.tar.xz.sha256",
+        )
+        run.assert_any_call(["tar", "-xf", str(source_path), "-C", str(tmp_path)], check=True)
+
+    def test_install_aborts_and_removes_source_when_checksum_fails(self, tmp_path):
+        """Checksum failures should stop the build and clean up the downloaded source."""
+        installer = SourceInstaller()
+        version = "3.12.1"
+        source_path = tmp_path / f"Python-{version}.tar.xz"
+
+        def fake_download(_url, destination):
+            Path(destination).write_bytes(b"tampered source archive")
+            return True
+
+        with (
+            patch.object(installer, "_install_dependencies", return_value=True),
+            patch("pyvm_updater.plugins.standard.tempfile.gettempdir", return_value=str(tmp_path)),
+            patch("pyvm_updater.plugins.standard.download_file", side_effect=fake_download),
+            patch("pyvm_updater.plugins.standard.verify_file_checksum", return_value=False) as verify_checksum,
+            patch("pyvm_updater.plugins.standard.subprocess.run") as run,
+        ):
+            assert installer.install(version) is False
+
+        verify_checksum.assert_called_once()
+        run.assert_not_called()
+        assert not source_path.exists()


### PR DESCRIPTION
This PR fixesissue no #202 - an integrity/security issue in SourceInstaller, where Python source tarballs downloaded from python.org were extracted and compiled without verifying their SHA256 checksum first.

Previously, WindowsInstaller verified downloaded installer files using the existing verify_file_checksum helper, but the Linux source-based installer skipped that step. That meant a corrupted or tampered Python-{version}.tar.xz archive could be compiled and installed if the download succeeded.

What Changed

Added SHA256 integrity verification to SourceInstaller.install.
Builds the checksum URL from the source tarball URL:
https://www.python.org/ftp/python/{version}/Python-{version}.tar.xz.sha256
Calls the existing verify_file_checksum(source_path, checksum_url) helper immediately after download.
Stops the installation before extraction if verification fails.
Removes the downloaded source tarball on checksum failure to avoid leaving corrupted files in the temp directory.
Keeps behavior aligned with WindowsInstaller, which already verifies downloaded installer artifacts.
Why This Matters

Source-based installs compile and execute code from the downloaded tarball. Verifying the checksum before extraction reduces the risk of installing corrupted or tampered source code and makes Linux source installs consistent with the Windows installer integrity checks.

Tests Added

Added regression tests for SourceInstaller covering:

Successful checksum verification before extraction/build.
Correct .tar.xz.sha256 checksum URL usage.
Aborting before any subprocess build/extract commands when checksum verification fails.
Cleanup of the downloaded tarball after checksum failure.

Testing-
Ran the full test suite:
py -3.14 -m pytest

Result:
123 passed